### PR TITLE
fix: remove default parallel for running go tests

### DIFF
--- a/dashboard-api/Makefile
+++ b/dashboard-api/Makefile
@@ -24,5 +24,5 @@ start: 		## Starts local containers
 	@docker compose up --build
 
 test:	## Runs the go tests 
-	@go test ./... -v
+	@go test ./... -p 1 -v
 


### PR DESCRIPTION
# Changelog

- as our test suite grows and as we use a database for integration tests, we are running into an issue that tests are affecting each other. This PR sets the tests to only run with `-parallel` set to 1 (by default Go sets this to GOMAXPROCS)