### PR TITLE
feat: create recruitment conf

### DIFF
--- a/dashboard-frontend/mocks/existingState.js
+++ b/dashboard-frontend/mocks/existingState.js
@@ -1,7 +1,7 @@
-import Select from './../src/pages/NewStudyPage/components/form/inputs/Select';
-import Text from './../src/pages/NewStudyPage/components/form/inputs/Text';
+import Select from '../src/pages/NewStudyPage/components/form/inputs/Select';
+import Text from '../src/pages/NewStudyPage/components/form/inputs/Text';
 
-const state = [
+const existingState = [
   {
     create_study: [
       {
@@ -12,7 +12,7 @@ const state = [
         label: 'Give your study a name',
         helper_text: 'E.g example-fly-conf',
         options: undefined,
-        value: '',
+        value: 'foo',
       },
     ],
     general: [
@@ -85,7 +85,7 @@ const state = [
             label: 'Store visits',
           },
         ],
-        value: 'default',
+        value: 'reach',
       },
       {
         id: 'optimization_goal',
@@ -200,7 +200,7 @@ const state = [
             label: 'Visit instagram profile',
           },
         ],
-        value: 'default',
+        value: 'social_impressions',
       },
       {
         id: 'destination_type',
@@ -227,7 +227,7 @@ const state = [
             label: 'App',
           },
         ],
-        value: 'default',
+        value: 'app',
       },
       {
         id: 'page_id',
@@ -237,7 +237,7 @@ const state = [
         label: 'Page Id',
         helper_text: 'E.g 1855355231229529',
         options: undefined,
-        value: '',
+        value: '12345',
       },
       {
         id: 'min_budget',
@@ -267,7 +267,7 @@ const state = [
         label: 'Instagram Id',
         helper_text: 'E.g 2327764173962588',
         options: undefined,
-        value: '',
+        value: '54321',
       },
       {
         id: 'ad_account',
@@ -277,10 +277,76 @@ const state = [
         label: 'Ad account',
         helper_text: 'E.g 1342820622846299',
         options: undefined,
-        value: '',
+        value: '111111',
+      },
+    ],
+    recruitment: [
+      {
+        id: 'recruitment_type',
+        name: 'recruitment_type',
+        type: 'select',
+        component: Select,
+        label: 'Select a recruitment type',
+        helper_text: undefined,
+        options: [
+          { name: 'recruitment_simple', label: 'Recruitment simple' },
+          { name: 'recruitment_pipeline', label: 'Recruitment pipeline' },
+          { name: 'recruitment_destination', label: 'Recruitment destination' },
+        ],
+        value: 'recruitment_simple',
+      },
+      {
+        id: 'ad_campaign_name',
+        name: 'ad_campaign_name',
+        type: 'text',
+        component: Text,
+        label: 'Ad campaign name',
+        helper_text: 'E.g vlab-vaping-pilot-2',
+        options: undefined,
+        value: 'vlab-most-used-prog-1',
+      },
+      {
+        id: 'budget',
+        name: 'budget',
+        type: 'number',
+        component: Text,
+        label: 'Budget',
+        helper_text: 'E.g 8400',
+        options: undefined,
+        value: 10000,
+      },
+      {
+        id: 'max_sample',
+        name: 'max_sample',
+        type: 'number',
+        component: Text,
+        label: 'Maximum sample',
+        helper_text: 'E.g 1000',
+        options: undefined,
+        value: 1000,
+      },
+      {
+        id: 'start_date',
+        name: 'start_date',
+        type: 'text',
+        component: Text,
+        label: 'Start date',
+        helper_text: 'E.g 2022-01-10',
+        options: undefined,
+        value: '2022-07-26T00:00:00',
+      },
+      {
+        id: 'end_date',
+        name: 'end_date',
+        type: 'text',
+        component: Text,
+        label: 'End date',
+        helper_text: 'E.g 2022-01-31',
+        options: undefined,
+        value: '2022-08-05T00:00:00',
       },
     ],
   },
 ];
 
-export default state;
+export default existingState;

--- a/dashboard-frontend/mocks/formData.js
+++ b/dashboard-frontend/mocks/formData.js
@@ -12,6 +12,13 @@ const formData = {
     instagram_id: '123',
     ad_account: 'some account',
   },
+  recruitment: {
+    end_date: '2022-08-05T00:00:00',
+    start_date: '2022-07-26T00:00:00',
+    ad_campaign_name: 'vlab-most-used-prog-1',
+    budget: 10000,
+    max_sample: 1000,
+  },
 };
 
 export default formData;

--- a/dashboard-frontend/mocks/initialState.js
+++ b/dashboard-frontend/mocks/initialState.js
@@ -1,0 +1,352 @@
+import Select from '../src/pages/NewStudyPage/components/form/inputs/Select';
+import Text from '../src/pages/NewStudyPage/components/form/inputs/Text';
+
+const initialState = [
+  {
+    create_study: [
+      {
+        id: 'name',
+        name: 'name',
+        type: 'text',
+        component: Text,
+        label: 'Give your study a name',
+        helper_text: 'E.g example-fly-conf',
+        options: undefined,
+        value: '',
+      },
+    ],
+    general: [
+      {
+        id: 'objective',
+        name: 'objective',
+        type: 'select',
+        component: Select,
+        label: 'Objective',
+        helper_text: undefined,
+        options: [
+          {
+            name: 'default',
+            label: 'Select an objective',
+          },
+          {
+            name: 'app_installs',
+            label: 'App installs',
+          },
+          {
+            name: 'brand_awareness',
+            label: 'Brand awareness',
+          },
+          {
+            name: 'conversions',
+            label: 'Conversions',
+          },
+          {
+            name: 'event_responses',
+            label: 'Event responses',
+          },
+          {
+            name: 'lead_generation',
+            label: 'Lead generation',
+          },
+          {
+            name: 'link_clicks',
+            label: 'Link clicks',
+          },
+          {
+            name: 'local_awareness',
+            label: 'Local awareness',
+          },
+          {
+            name: 'messages',
+            label: 'Messages',
+          },
+          {
+            name: 'offer_claims',
+            label: 'Offer claims',
+          },
+          {
+            name: 'page_likes',
+            label: 'Page likes',
+          },
+          {
+            name: 'post_engagement',
+            label: 'Post engagement',
+          },
+          {
+            name: 'product_catalog_sales',
+            label: 'Product catalog sales',
+          },
+          {
+            name: 'reach',
+            label: 'Reach',
+          },
+          {
+            name: 'store_visits',
+            label: 'Store visits',
+          },
+        ],
+        value: 'default',
+      },
+      {
+        id: 'optimization_goal',
+        name: 'optimization_goal',
+        type: 'select',
+        component: Select,
+        label: 'Optimization goal',
+        helper_text: undefined,
+        options: [
+          {
+            name: 'default',
+            label: 'Select an optimization goal',
+          },
+          {
+            name: 'ad_recall_lift',
+            label: 'Ad recall lift',
+          },
+          {
+            name: 'app_downloads',
+            label: 'App downloads',
+          },
+          {
+            name: 'app_installs',
+            label: 'App installs',
+          },
+          {
+            name: 'brand_awareness',
+            label: 'Brand awareness',
+          },
+          {
+            name: 'clicks',
+            label: 'Clicks',
+          },
+          {
+            name: 'derived_events',
+            label: 'Derived events',
+          },
+          {
+            name: 'engaged_users',
+            label: 'Engaged users',
+          },
+          {
+            name: 'event_responses',
+            label: 'Event responses',
+          },
+          {
+            name: 'impressions',
+            label: 'Impressions',
+          },
+          {
+            name: 'landing_page_views',
+            label: 'Landing page views',
+          },
+          {
+            name: 'lead_generation',
+            label: 'Lead generation',
+          },
+          {
+            name: 'link_clicks',
+            label: 'Link clicks',
+          },
+          {
+            name: 'none',
+            label: 'None',
+          },
+          {
+            name: 'offer_claims',
+            label: 'Offer claims',
+          },
+          {
+            name: 'offsite_conversions',
+            label: 'Offsite conversions',
+          },
+          {
+            name: 'page_engagement',
+            label: 'Page engagement',
+          },
+          {
+            name: 'page_likes',
+            label: 'Page likes',
+          },
+          {
+            name: 'post_engagement',
+            label: 'Post engagement',
+          },
+          {
+            name: 'reach',
+            label: 'Reach',
+          },
+          {
+            name: 'replies',
+            label: 'Replies',
+          },
+          {
+            name: 'replies',
+            label: 'Replies',
+          },
+          {
+            name: 'social_impressions',
+            label: 'Social impressions',
+          },
+          {
+            name: 'thruplay',
+            label: 'Thruplay',
+          },
+          {
+            name: 'two_second_continuous_video_views',
+            label: 'Two second continuous video views',
+          },
+          {
+            name: 'visit_instagram_profile',
+            label: 'Visit instagram profile',
+          },
+        ],
+        value: 'default',
+      },
+      {
+        id: 'destination_type',
+        name: 'destination_type',
+        type: 'select',
+        component: Select,
+        label: 'Destination type',
+        helper_text: undefined,
+        options: [
+          {
+            name: 'default',
+            label: 'Select a destination type',
+          },
+          {
+            name: 'web',
+            label: 'Web',
+          },
+          {
+            name: 'messenger',
+            label: 'Messenger',
+          },
+          {
+            name: 'app',
+            label: 'App',
+          },
+        ],
+        value: 'default',
+      },
+      {
+        id: 'page_id',
+        name: 'page_id',
+        type: 'text',
+        component: Text,
+        label: 'Page Id',
+        helper_text: 'E.g 1855355231229529',
+        options: undefined,
+        value: '',
+      },
+      {
+        id: 'min_budget',
+        name: 'min_budget',
+        type: 'number',
+        component: Text,
+        label: 'Minimum budget',
+        helper_text: 'E.g 10',
+        options: undefined,
+        value: 1,
+      },
+      {
+        id: 'opt_window',
+        name: 'opt_window',
+        type: 'number',
+        component: Text,
+        label: 'Opt window',
+        helper_text: 'E.g 48',
+        options: undefined,
+        value: 1,
+      },
+      {
+        id: 'instagram_id',
+        name: 'instagram_id',
+        type: 'text',
+        component: Text,
+        label: 'Instagram Id',
+        helper_text: 'E.g 2327764173962588',
+        options: undefined,
+        value: '',
+      },
+      {
+        id: 'ad_account',
+        name: 'ad_account',
+        type: 'text',
+        component: Text,
+        label: 'Ad account',
+        helper_text: 'E.g 1342820622846299',
+        options: undefined,
+        value: '',
+      },
+    ],
+    recruitment: [
+      {
+        id: 'recruitment_type',
+        name: 'recruitment_type',
+        type: 'select',
+        component: Select,
+        label: 'Select a recruitment type',
+        helper_text: undefined,
+        options: [
+          { name: 'recruitment_simple', label: 'Recruitment simple' },
+          { name: 'recruitment_pipeline', label: 'Recruitment pipeline' },
+          { name: 'recruitment_destination', label: 'Recruitment destination' },
+        ],
+        value: 'recruitment_simple',
+      },
+      {
+        id: 'ad_campaign_name',
+        name: 'ad_campaign_name',
+        type: 'text',
+        component: Text,
+        label: 'Ad campaign name',
+        helper_text: 'E.g vlab-vaping-pilot-2',
+        options: undefined,
+        value: '',
+      },
+      {
+        id: 'budget',
+        name: 'budget',
+        type: 'number',
+        component: Text,
+        label: 'Budget',
+        helper_text: 'E.g 8400',
+        options: undefined,
+        value: 1,
+      },
+      {
+        id: 'max_sample',
+        name: 'max_sample',
+        type: 'number',
+        component: Text,
+        label: 'Maximum sample',
+        helper_text: 'E.g 1000',
+        options: undefined,
+        value: 1,
+      },
+      {
+        id: 'start_date',
+        name: 'start_date',
+        type: 'text',
+        component: Text,
+        label: 'Start date',
+        helper_text: 'E.g 2022-01-10',
+        options: undefined,
+        value: '',
+      },
+      {
+        id: 'end_date',
+        name: 'end_date',
+        type: 'text',
+        component: Text,
+        label: 'End date',
+        helper_text: 'E.g 2022-01-31',
+        options: undefined,
+        value: '',
+      },
+    ],
+  },
+];
+
+export default initialState;

--- a/dashboard-frontend/mocks/translatedConf.js
+++ b/dashboard-frontend/mocks/translatedConf.js
@@ -1,0 +1,50 @@
+import { simple } from '../src/pages/StudyConfPage/configs/recruitment/simple';
+import { pipeline_experiment } from '../src/pages/StudyConfPage/configs/recruitment/pipeline_experiment';
+import { destination } from '../src/pages/StudyConfPage/configs/recruitment/destination';
+
+const translatedConf = {
+  type: 'confSelect',
+  title: 'Recruitment',
+  description:
+    'The "recruitment" configuration describes how/where recruitment will take place. Every study needs to recruit from somewhere.',
+  fields: [
+    {
+      name: 'recruitment_type',
+      type: 'select',
+      label: 'Select a recruitment type',
+      options: [simple, pipeline_experiment, destination],
+    },
+    {
+      name: 'ad_campaign_name',
+      type: 'text',
+      label: 'Ad campaign name',
+      helper_text: 'E.g vlab-vaping-pilot-2',
+    },
+    {
+      name: 'budget',
+      type: 'number',
+      label: 'Budget',
+      helper_text: 'E.g 8400',
+    },
+    {
+      name: 'max_sample',
+      type: 'number',
+      label: 'Maximum sample',
+      helper_text: 'E.g 1000',
+    },
+    {
+      name: 'start_date',
+      type: 'text',
+      label: 'Start date',
+      helper_text: 'E.g 2022-01-10',
+    },
+    {
+      name: 'end_date',
+      type: 'text',
+      label: 'End date',
+      helper_text: 'E.g 2022-01-31',
+    },
+  ],
+};
+
+export default translatedConf;

--- a/dashboard-frontend/src/helpers/getField.spec.ts
+++ b/dashboard-frontend/src/helpers/getField.spec.ts
@@ -5,8 +5,8 @@ import { general } from '../pages/StudyConfPage/configs/general';
 
 describe('getField', () => {
   it('given some fields and an event it returns the field on which the event occurred', () => {
-    const config = general;
-    const fields = initialiseFieldState(config);
+    const conf = general;
+    const fields = initialiseFieldState(conf);
     const event = {
       name: 'instagram_id',
       value: 'foo',

--- a/dashboard-frontend/src/helpers/getSelectedConf.spec.ts
+++ b/dashboard-frontend/src/helpers/getSelectedConf.spec.ts
@@ -1,0 +1,58 @@
+import { recruitment } from '../pages/StudyConfPage/configs/recruitment/base';
+import { getSelectedConf } from './getSelectedConf';
+import { pipeline_experiment } from '../pages/StudyConfPage/configs/recruitment/pipeline_experiment';
+import { simple } from '../pages/StudyConfPage/configs/recruitment/simple';
+import { destination } from '../pages/StudyConfPage/configs/recruitment/destination';
+
+describe('getSelectedConf', () => {
+  it('given a recruitment conf and some form data it returns the nested conf from which the form data derives', () => {
+    const localFormData = {
+      end_date: '2022-07-27T00:00:00',
+      start_date: '2022-07-26T00:00:00',
+      max_sample: 'iron-overload-men',
+      budget: 10000,
+      ad_campaign_name: 'test-123',
+    };
+
+    const expectation = simple;
+
+    const res = getSelectedConf(recruitment, localFormData);
+
+    expect(res).toStrictEqual(expectation);
+  });
+
+  it('works with a different set of form data', () => {
+    const localFormData = {
+      end_date: '2022-07-27T00:00:00',
+      start_date: '2022-07-26T00:00:00',
+      arms: 2,
+      recruitment_days: 10,
+      offset_days: 20,
+      ad_campaign_name_base: 'iron-overload-men',
+      budget_per_arm: 10000,
+      max_sample_per_arm: 100,
+    };
+
+    const expectation = pipeline_experiment;
+
+    const res = getSelectedConf(recruitment, localFormData);
+
+    expect(res).toStrictEqual(expectation);
+  });
+
+  it('works with form data that is made up of fields shared across multiple recruitment types', () => {
+    const localFormData = {
+      end_date: '2022-07-27T00:00:00',
+      start_date: '2022-07-26T00:00:00',
+      ad_campaign_name_base: 'iron-overload-men',
+      budget_per_arm: 10000,
+      max_sample_per_arm: 100,
+    };
+
+    const expectation = destination;
+
+    const res = getSelectedConf(recruitment, localFormData);
+
+    expect(res).toStrictEqual(expectation);
+  });
+});

--- a/dashboard-frontend/src/helpers/getSelectedConf.ts
+++ b/dashboard-frontend/src/helpers/getSelectedConf.ts
@@ -1,0 +1,16 @@
+export const getSelectedConf = (conf: any, localFormData: any) => {
+  const formDataKeys = Object.keys(localFormData);
+
+  const getFieldKeys = (conf: any) => {
+    return conf.fields.map((f: any) => f.name);
+  };
+
+  const checker = (arr: any[], target: any[]) =>
+    target.every(v => arr.includes(v));
+
+  const index = conf.selector.options.findIndex((option: any) =>
+    checker(formDataKeys, getFieldKeys(option))
+  );
+
+  return conf.selector.options[index];
+};

--- a/dashboard-frontend/src/helpers/state.spec.ts
+++ b/dashboard-frontend/src/helpers/state.spec.ts
@@ -2,14 +2,14 @@ import { getFieldState, initialiseFieldState, updateFieldState } from './state';
 import { getField } from './getField';
 import { general } from '../pages/StudyConfPage/configs/general';
 import { create_study } from '../pages/NewStudyPage/configs/create_study';
-import state from '../../mocks/state';
+import initialState from '../../mocks/initialState';
 import formData from '../../mocks/formData';
 
 describe('initialiseFieldState', () => {
   it('given a conf it returns some initial field state when no state is defined', () => {
     const conf = create_study;
 
-    const expectation = state[0]['create_study'];
+    const expectation = initialState[0]['create_study'];
 
     const res = initialiseFieldState(conf);
 
@@ -19,7 +19,7 @@ describe('initialiseFieldState', () => {
   it('works for a study conf too', () => {
     const conf = general;
 
-    const expectation = state[0]['general'];
+    const expectation = initialState[0]['general'];
 
     const res = initialiseFieldState(conf);
 
@@ -44,7 +44,7 @@ describe('getFieldState', () => {
 
 describe('updateFieldState', () => {
   it('given some field state and an event it can update the target field with the value from that event', () => {
-    const fieldState = state[0]['general'];
+    const fieldState = initialState[0]['general'];
 
     const event = {
       name: 'instagram_id',
@@ -62,7 +62,7 @@ describe('updateFieldState', () => {
   });
 
   it('works when the event occurrs on a select component', () => {
-    const fieldState = state[0]['general'];
+    const fieldState = initialState[0]['general'];
 
     const event = {
       name: 'objective',
@@ -76,6 +76,24 @@ describe('updateFieldState', () => {
 
     expect(updatedField.value).toEqual('link_clicks');
     expect(updatedField.value).not.toEqual('link_clicks!');
+    expect(updatedField.value).toEqual(event.value);
+  });
+
+  it('works when the event occurs on a select component with nested confs', () => {
+    const fieldState = initialState[0]['recruitment'];
+
+    const event = {
+      name: 'recruitment_type',
+      value: 'recruitment_pipeline',
+      type: 'change',
+    };
+
+    const res = updateFieldState(fieldState, event);
+
+    const updatedField = getField(res, event);
+
+    expect(updatedField.value).toEqual('recruitment_pipeline');
+    expect(updatedField.value).not.toEqual('recruitment_simple');
     expect(updatedField.value).toEqual(event.value);
   });
 });

--- a/dashboard-frontend/src/helpers/translateConf.spec.ts
+++ b/dashboard-frontend/src/helpers/translateConf.spec.ts
@@ -1,0 +1,17 @@
+import { translateConf } from './translateConf';
+import { recruitment } from '../pages/StudyConfPage/configs/recruitment/base';
+import { simple } from '../pages/StudyConfPage/configs/recruitment/simple';
+import translatedConf from '../../mocks/translatedConf';
+
+describe('translateConf', () => {
+  it('given two confs it translates them into one', () => {
+    const baseConf = recruitment;
+    const dynamicConf = simple;
+
+    const expectation = translatedConf;
+
+    const res = translateConf(baseConf, dynamicConf);
+
+    expect(res).toStrictEqual(expectation);
+  });
+});

--- a/dashboard-frontend/src/helpers/translateConf.ts
+++ b/dashboard-frontend/src/helpers/translateConf.ts
@@ -1,0 +1,28 @@
+import { ConfBase, ConfSelectBase } from '../types/form';
+
+export const translateConf = (
+  conf: ConfSelectBase,
+  selectedConfig: ConfBase
+) => {
+  const base: any = {
+    fields: [
+      {
+        name: conf.selector.name,
+        type: conf.selector.type,
+        label: conf.selector.label,
+        options: conf.selector.options,
+      },
+    ],
+  };
+
+  const clone = {
+    ...conf,
+    fields: conf.fields
+      ? base.fields.concat(selectedConfig.fields).concat(conf.fields)
+      : base.fields.concat(selectedConfig.fields),
+  };
+
+  const { selector, ...newConfig } = clone;
+
+  return newConfig;
+};

--- a/dashboard-frontend/src/pages/NewStudyPage/NewStudyPage.tsx
+++ b/dashboard-frontend/src/pages/NewStudyPage/NewStudyPage.tsx
@@ -1,7 +1,7 @@
 import PageLayout from '../../components/PageLayout';
 import { ConfBase } from '../../types/form';
 import Form from './components/form/Form';
-import simple from './controllers/simple';
+import simple from '../StudyConfPage/controllers/simple';
 import { create_study } from './configs/create_study';
 
 const NewStudyPage = () => (

--- a/dashboard-frontend/src/pages/StudyConfPage/StudyConfPage.tsx
+++ b/dashboard-frontend/src/pages/StudyConfPage/StudyConfPage.tsx
@@ -1,14 +1,16 @@
 import { useState } from 'react';
 import PageLayout from '../../components/PageLayout';
 import { general } from './configs/general';
+import { recruitment } from './configs/recruitment/base';
 import Form from '../NewStudyPage/components/form/Form';
-import simple from '../NewStudyPage/controllers/simple';
 import Navbar from './components/NavBar';
 import { useParams } from 'react-router-dom';
 import useStudyConf from '../../hooks/useStudyConf';
 import ErrorPlaceholder from '../../components/ErrorPlaceholder';
 import useStudy from '../../hooks/useStudy';
-import { ConfBase } from '../../types/form';
+import { ConfBase, ConfSelectBase } from '../../types/form';
+import simple from './controllers/simple';
+import select from './controllers/select';
 
 const StudyConfPage = () => {
   const params = useParams<{ studySlug: string }>();
@@ -41,17 +43,19 @@ const StudyConfPage = () => {
 };
 
 const PageContent = (data: any) => {
-  const confStore: Record<string, ConfBase> = {
+  const confStore: Record<string, ConfBase | ConfSelectBase> = {
     general,
+    recruitment,
   };
 
   const confKeys = Object.keys(confStore);
   const confsToArr = Object.entries(confStore);
   const [index, setIndex] = useState<number>(0);
-  const conf: ConfBase = confsToArr[index][1];
+  const conf = confsToArr[index][1];
 
   const lookup: any = {
     confObject: simple,
+    confSelect: select,
   };
 
   const str: keyof ConfBase = 'type';

--- a/dashboard-frontend/src/pages/StudyConfPage/configs/recruitment/base.js
+++ b/dashboard-frontend/src/pages/StudyConfPage/configs/recruitment/base.js
@@ -1,0 +1,16 @@
+import { simple } from './simple';
+import { pipeline_experiment } from './pipeline_experiment';
+import { destination } from './destination';
+
+export const recruitment = {
+  type: 'confSelect',
+  title: 'Recruitment',
+  description:
+    'The "recruitment" configuration describes how/where recruitment will take place. Every study needs to recruit from somewhere.',
+  selector: {
+    name: 'recruitment_type',
+    type: 'select',
+    label: 'Select a recruitment type',
+    options: [simple, pipeline_experiment, destination],
+  },
+};

--- a/dashboard-frontend/src/pages/StudyConfPage/configs/recruitment/destination.js
+++ b/dashboard-frontend/src/pages/StudyConfPage/configs/recruitment/destination.js
@@ -1,0 +1,38 @@
+export const destination = {
+  type: 'confObject',
+  title: 'Recruitment destination',
+  description:
+    ' Use this when you want to create a multi-arm randomized experiment (A/B test on Facebook) where some of your sample is sent to different "destinations".',
+  fields: [
+    {
+      name: 'ad_campaign_name_base',
+      type: 'text',
+      label: 'Ad campaign name base',
+      helper_text: 'E.g vlab-vaping-pilot-2',
+    },
+    {
+      name: 'budget_per_arm',
+      type: 'number',
+      label: 'Budget per arm',
+      helper_text: 'E.g 8400',
+    },
+    {
+      name: 'max_sample_per_arm',
+      type: 'number',
+      label: 'Maximum sample per arm',
+      helper_text: 'E.g 1000',
+    },
+    {
+      name: 'start_date',
+      type: 'text',
+      label: 'Start date',
+      helper_text: 'E.g 2022-01-10',
+    },
+    {
+      name: 'end_date',
+      type: 'text',
+      label: 'End date',
+      helper_text: 'E.g 2022-01-31',
+    },
+  ],
+};

--- a/dashboard-frontend/src/pages/StudyConfPage/configs/recruitment/pipeline_experiment.js
+++ b/dashboard-frontend/src/pages/StudyConfPage/configs/recruitment/pipeline_experiment.js
@@ -1,0 +1,56 @@
+export const pipeline_experiment = {
+  type: 'confObject',
+  title: 'Recruitment pipeline',
+  description:
+    'In this design, we generate an A/B test on Facebook but instead of sending your sample to different destinations, we run the ads at different times (a pipeline experiment design). You can set up how long each arm runs, and how long they are offset from the start of the previous arm.',
+  fields: [
+    {
+      name: 'ad_campaign_name_base',
+      type: 'text',
+      label: 'Ad campaign name base',
+      helper_text: 'E.g vlab-vaping-pilot-2',
+    },
+    {
+      name: 'budget_per_arm',
+      type: 'number',
+      label: 'Budget per arm',
+      helper_text: 'E.g 8400',
+    },
+    {
+      name: 'max_sample_per_arm',
+      type: 'number',
+      label: 'Maximum sample per arm',
+      helper_text: 'E.g 1000',
+    },
+    {
+      name: 'start_date',
+      type: 'text',
+      label: 'Start date',
+      helper_text: 'E.g 2022-01-10',
+    },
+    {
+      name: 'end_date',
+      type: 'text',
+      label: 'End date',
+      helper_text: 'E.g 2022-01-31',
+    },
+    {
+      name: 'arms',
+      type: 'number',
+      label: 'Arms',
+      helper_text: 'E.g 2',
+    },
+    {
+      name: 'recruitment_days',
+      type: 'number',
+      label: 'Recruitment Days',
+      helper_text: 'E.g 10',
+    },
+    {
+      name: 'offset_days',
+      type: 'number',
+      label: 'Offset Days',
+      helper_text: 'E.g 20',
+    },
+  ],
+};

--- a/dashboard-frontend/src/pages/StudyConfPage/configs/recruitment/simple.js
+++ b/dashboard-frontend/src/pages/StudyConfPage/configs/recruitment/simple.js
@@ -1,0 +1,37 @@
+export const simple = {
+  type: 'confObject',
+  title: 'Recruitment simple',
+  description: 'Simple recruitment...',
+  fields: [
+    {
+      name: 'ad_campaign_name',
+      type: 'text',
+      label: 'Ad campaign name',
+      helper_text: 'E.g vlab-vaping-pilot-2',
+    },
+    {
+      name: 'budget',
+      type: 'number',
+      label: 'Budget',
+      helper_text: 'E.g 8400',
+    },
+    {
+      name: 'max_sample',
+      type: 'number',
+      label: 'Maximum sample',
+      helper_text: 'E.g 1000',
+    },
+    {
+      name: 'start_date',
+      type: 'text',
+      label: 'Start date',
+      helper_text: 'E.g 2022-01-10',
+    },
+    {
+      name: 'end_date',
+      type: 'text',
+      label: 'End date',
+      helper_text: 'E.g 2022-01-31',
+    },
+  ],
+};

--- a/dashboard-frontend/src/pages/StudyConfPage/controllers/select.spec.ts
+++ b/dashboard-frontend/src/pages/StudyConfPage/controllers/select.spec.ts
@@ -1,0 +1,53 @@
+import initialState from '../../../../mocks/initialState';
+import { recruitment } from '../configs/recruitment/base';
+import select from './select';
+import formData from '../../../../mocks/formData';
+import existingState from '../../../../mocks/existingState';
+import { getField } from '../../../helpers/getField';
+
+describe('select controller', () => {
+  it('given a recruitment conf it returns some initial fields when no state is defined', () => {
+    const expectation = initialState[0].recruitment;
+
+    const res = select(recruitment);
+
+    expect(res).toStrictEqual(expectation);
+  });
+
+  it('given a recruitment conf and some form data it returns a set of fields with their existing state', () => {
+    const conf = recruitment;
+
+    const localFormData = formData['recruitment'];
+
+    const res = select(conf, localFormData);
+
+    const expectation = existingState[0]['recruitment'];
+
+    expect(res).toEqual(expectation);
+  });
+
+  it('given a recruitment conf, some form data and an event it updates the value of the field on which the event occurred', () => {
+    const conf = recruitment;
+
+    const localFormData = formData['recruitment'];
+
+    const state = existingState[0].recruitment;
+
+    const event = {
+      name: `ad_campaign_name`,
+      value: 'foo',
+      type: 'change',
+    };
+
+    const newValue = event.value;
+    const prevValue = formData['recruitment']['ad_campaign_name'];
+
+    const res = select(conf, localFormData, event, state);
+
+    const targetField = res && getField(res, event);
+
+    expect(targetField?.value).toStrictEqual(newValue);
+    expect(targetField?.value).not.toEqual(prevValue);
+    expect(targetField?.value).toStrictEqual('foo');
+  });
+});

--- a/dashboard-frontend/src/pages/StudyConfPage/controllers/select.ts
+++ b/dashboard-frontend/src/pages/StudyConfPage/controllers/select.ts
@@ -1,0 +1,83 @@
+import { ConfBase, ConfSelectBase, FieldState } from '../../../types/form';
+import { translateConf } from '../../../helpers/translateConf';
+import {
+  getFieldState,
+  initialiseFieldState,
+  updateFieldState,
+  Event,
+} from '../../../helpers/state';
+import { createNameFor } from '../../../helpers/strings';
+import { Conf } from '../../../types/conf';
+import { getSelectedConf } from '../../../helpers/getSelectedConf';
+
+const recruitment = (
+  conf: ConfSelectBase,
+  localFormData?: Conf,
+  event?: Event,
+  fieldState?: FieldState[]
+) => {
+  const getConf = (baseConf: ConfSelectBase, dynamicConf: any) => {
+    return dynamicConf && translateConf(baseConf, dynamicConf);
+  };
+
+  if (!localFormData && !fieldState && !event) {
+    const defaultConf = conf.selector?.options[0];
+
+    const translatedConf = getConf(conf, defaultConf);
+
+    return initialiseFieldState(translatedConf);
+  }
+
+  if (localFormData && !fieldState && !event) {
+    const selectedConf: ConfBase = getSelectedConf(conf, localFormData);
+
+    const translatedConf = getConf(conf, selectedConf);
+
+    const translateFormData = (conf: ConfBase) => {
+      return {
+        recruitment_type: createNameFor(conf.title),
+        ...localFormData,
+      };
+    };
+
+    const translatedFormData = translateFormData(selectedConf);
+
+    return getFieldState(translatedConf, translatedFormData);
+  }
+
+  if (!localFormData && fieldState && event) {
+    if (event.name === conf.selector.name) {
+      const index: number = conf.selector.options.findIndex(
+        (option: ConfBase) => createNameFor(option.title) === event?.value
+      );
+
+      const selectedConf: ConfBase = conf.selector.options[index];
+
+      const translatedConf = getConf(conf, selectedConf);
+
+      const globalState = initialiseFieldState(translatedConf);
+
+      return globalState && updateFieldState(globalState, event);
+    }
+  }
+
+  if (localFormData && fieldState && event) {
+    if (event.name === conf.selector.name) {
+      const index: number = conf.selector.options.findIndex(
+        (option: ConfBase) => createNameFor(option.title) === event.value
+      );
+
+      const selectedConf: ConfBase = conf.selector.options[index];
+
+      const translatedConf = getConf(conf, selectedConf);
+
+      const globalState = initialiseFieldState(translatedConf);
+
+      return globalState && updateFieldState(globalState, event);
+    }
+
+    return updateFieldState(fieldState, event);
+  }
+};
+
+export default recruitment;

--- a/dashboard-frontend/src/pages/StudyConfPage/controllers/simple.spec.ts
+++ b/dashboard-frontend/src/pages/StudyConfPage/controllers/simple.spec.ts
@@ -1,12 +1,12 @@
-import simple from './simple';
 import { initialiseFieldState } from '../../../helpers/state';
-import { general } from '../../StudyConfPage/configs/general';
+import { general } from '../configs/general';
 import { getField } from '../../../helpers/getField';
-import { create_study } from '../configs/create_study';
-import state from '../../../../mocks/state';
+import { create_study } from '../../NewStudyPage/configs/create_study';
+import initialState from '../../../../mocks/initialState';
 import Text from '../../NewStudyPage/components/form/inputs/Text';
 import { translateField } from '../../../helpers/translateField';
 import formData from '../../../../mocks/formData';
+import simple from './simple';
 
 describe('simple controller', () => {
   it('given a conf it returns some initial fields when no state is defined', () => {
@@ -22,9 +22,7 @@ describe('simple controller', () => {
   it('given a conf and some form data it returns a set of fields with their existing state', () => {
     const conf = create_study;
 
-    const localFormData = {
-      name: 'baz',
-    };
+    const localFormData = formData['create_study'];
 
     const res = simple(conf, localFormData);
 
@@ -37,7 +35,7 @@ describe('simple controller', () => {
         label: 'Give your study a name',
         helper_text: 'E.g example-fly-conf',
         options: undefined,
-        value: 'baz',
+        value: 'foo',
       },
     ];
 
@@ -67,7 +65,7 @@ describe('simple controller', () => {
       type: 'change',
     };
 
-    const fieldState = state[0].create_study;
+    const fieldState = initialState[0].create_study;
 
     const newValue = event.value;
     const prevValue = 'foo';
@@ -86,7 +84,7 @@ describe('simple controller', () => {
 
     const localFormData = formData['general'];
 
-    const initialState = state[0].general;
+    const state = initialState[0].general;
 
     const event = {
       name: `instagram_id`,
@@ -95,14 +93,13 @@ describe('simple controller', () => {
     };
 
     const newValue = event.value;
-    const prevValue = 'foo';
+    const prevValue = formData['general']['instagram_id'];
 
-    const res = simple(conf, localFormData, event, initialState);
+    const res = simple(conf, localFormData, event, state);
 
     const targetField = res && getField(res, event);
     expect(targetField?.value).toStrictEqual(newValue);
-    expect(targetField?.value).toStrictEqual('baz');
-    expect(targetField?.value).toStrictEqual(event.value);
     expect(targetField?.value).not.toEqual(prevValue);
+    expect(targetField?.value).toStrictEqual('baz');
   });
 });

--- a/dashboard-frontend/src/pages/StudyConfPage/controllers/simple.ts
+++ b/dashboard-frontend/src/pages/StudyConfPage/controllers/simple.ts
@@ -4,8 +4,8 @@ import {
   Event,
   getFieldState,
 } from '../../../helpers/state';
+import { FieldState, ConfBase } from '../../../types/form';
 import { Conf } from '../../../types/conf';
-import { ConfBase, FieldState } from '../../../types/form';
 
 const simple = (
   conf: ConfBase,

--- a/dashboard-frontend/src/types/conf.ts
+++ b/dashboard-frontend/src/types/conf.ts
@@ -13,4 +13,28 @@ export interface General {
   ad_account: string;
 }
 
-export type Conf = CreateStudy | General;
+export type Recruitment = RecruitmentSimple | Destination | PipelineExperiment;
+
+export interface RecruitmentSimple {
+  ad_campaign_name: string;
+  budget: number;
+  end_date: string;
+  max_sample: number;
+  start_date: string;
+}
+
+export interface Destination {
+  ad_campaign_name_base: string;
+  budget_per_arm: number;
+  end_date: string;
+  max_sample_per_arm: number;
+  start_date: string;
+}
+
+export interface PipelineExperiment extends Destination {
+  arms: number;
+  recruitment_days: number;
+  offset_days: number;
+}
+
+export type Conf = CreateStudy | General | Recruitment;

--- a/dashboard-frontend/src/types/form.ts
+++ b/dashboard-frontend/src/types/form.ts
@@ -5,6 +5,13 @@ export interface ConfBase extends Record<string, any> {
   fields: FieldBase[];
 }
 
+export interface ConfSelectBase extends Record<string, any> {
+  title: string;
+  type: string;
+  description: string;
+  selector: any;
+}
+
 export interface FieldBase {
   name: string;
   type: string;


### PR DESCRIPTION
# Changelog

- created a single select form that renders a dropdown where the user can select from 3 recruitment types
- the user can see previously configured recruitment data
- known issue #162