### PR TITLE
fix: typeform tests

### DIFF
--- a/.github/workflows/adopt.yaml
+++ b/.github/workflows/adopt.yaml
@@ -4,6 +4,10 @@ on:
     paths:
       - "adopt/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Tests

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -12,6 +12,10 @@ on:
     paths:
      - "api/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Runs the Dashboard API Tests
   tests:

--- a/.github/workflows/inference.yaml
+++ b/.github/workflows/inference.yaml
@@ -12,7 +12,30 @@ on:
     paths:
      - "inference/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  # Runs test for the inference connectors
+  test:
+    name: Tests
+    runs-on: ubuntu-20.04
+    env:
+      PG_URL: postgres://root@localhost:5433/test
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Setup Golang
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.18'
+      - name: Setup Database
+        run: make test-db
+        working-directory: ./inference
+      - name: Run Tests
+        run: make test
+        working-directory: ./inference
   # Builds the Inference Containers
   build:
     strategy:
@@ -20,6 +43,8 @@ jobs:
         connector: ['fly', 'typeform', 'alchemer']
     runs-on: ubuntu-latest
     name: Build Image
+    needs:
+      - test
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU
@@ -42,7 +67,7 @@ jobs:
             type=sha,format=long,prefix=,priority=200
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/connectors') }},priority=100
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: inference/Dockerfile
           context: inference/

--- a/inference/Makefile
+++ b/inference/Makefile
@@ -13,3 +13,8 @@ fly:
 typeform:
 	@go build -o typeform sources/typeform/main.go
 
+test:		## Runs the go tests 
+	@go test ./... -p 1
+
+test-db: 	## Starts up the test database in the devops directory
+	$(MAKE) -C ../devops test-db

--- a/inference/sources/typeform/main_test.go
+++ b/inference/sources/typeform/main_test.go
@@ -88,7 +88,7 @@ func TestGetResponses_WorksWithSinglePageFromExampleJson(t *testing.T) {
 		Config: []byte(`foo`),
 	}
 
-	events := tc.GetResponses(&Source{"mystudy", cnf}, "formfoo", "", 0)
+	events := tc.GetResponses(&Source{"mystudy", cnf, nil}, "formfoo", "", 0)
 
 	e := Sliceit(events)
 	dataAssertions(t, e)
@@ -129,7 +129,7 @@ func TestGetResponses_PaginatesWhenPageIsFull(t *testing.T) {
 		Config: []byte(`foo`),
 	}
 
-	events := tc.GetResponses(&Source{"mystudy", cnf}, "formfoo", "oldtoken", 0)
+	events := tc.GetResponses(&Source{"mystudy", cnf, nil}, "formfoo", "oldtoken", 0)
 
 	e := Sliceit(events)
 	dataAssertions(t, e)
@@ -154,7 +154,7 @@ func TestGetResponses_AddsHiddenFieldsAsUserMetadata(t *testing.T) {
 		Config: []byte(`foo`),
 	}
 
-	events := tc.GetResponses(&Source{"mystudy", cnf}, "formfoo", "", 0)
+	events := tc.GetResponses(&Source{"mystudy", cnf, nil}, "formfoo", "", 0)
 
 	e := Sliceit(events)
 
@@ -187,7 +187,7 @@ func TestGetResponses_StartsFromOldIdxAndIterates(t *testing.T) {
 		Config: []byte(`foo`),
 	}
 
-	events := tc.GetResponses(&Source{"mystudy", cnf}, "formfoo", "oldtoken", 350)
+	events := tc.GetResponses(&Source{"mystudy", cnf, nil}, "formfoo", "oldtoken", 350)
 
 	e := Sliceit(events)
 


### PR DESCRIPTION
# Changelog

- fixes typeform tests
- adds automated testing for Inference connectors

**Note**: we should move the typeform connector to use credentials from the database and not an environment variable