### PR TITLE
feat(dashboard): pure Facebook targeting extraction module and shared renderer

### DIFF
--- a/dashboard/src/helpers/numbers.spec.ts
+++ b/dashboard/src/helpers/numbers.spec.ts
@@ -17,40 +17,28 @@ describe('calculatePercentage', () => {
   });
 
   it('throws error when total is 0', () => {
-    try {
-      expect.assertions(2);
-      calculatePercentage({ current: 0, total: 0 });
-    } catch (err: any) {
-      expect(err).toBeInstanceOf(UnexpectedNumberError);
-      expect(err.message).toBe('`total` cannot be 0');
-    }
+    expect(() => calculatePercentage({ current: 0, total: 0 })).toThrow(
+      new UnexpectedNumberError('`total` cannot be 0')
+    );
   });
 
   it('throws error when current is greater than total', () => {
-    try {
-      expect.assertions(2);
-      calculatePercentage({ current: 100, total: 10 });
-    } catch (err: any) {
-      expect(err).toBeInstanceOf(UnexpectedNumberError);
-      expect(err.message).toBe('`current` cannot be greater than `total`');
-    }
+    expect(() => calculatePercentage({ current: 100, total: 10 })).toThrow(
+      new UnexpectedNumberError('`current` cannot be greater than `total`')
+    );
   });
 
   INVALID_NUMBERS.forEach(invalidNumber => {
-    it(`throws error when any of the values provided is ${invalidNumber}`, () => {
-      expect.assertions(2);
+    it(`throws error when current is ${invalidNumber}`, () => {
+      expect(() => calculatePercentage({ current: invalidNumber, total: 100 })).toThrow(
+        InvalidNumberError
+      );
+    });
 
-      try {
-        calculatePercentage({ current: invalidNumber, total: 100 });
-      } catch (err) {
-        expect(err).toBeInstanceOf(InvalidNumberError);
-      }
-
-      try {
-        calculatePercentage({ current: 10, total: invalidNumber });
-      } catch (err) {
-        expect(err).toBeInstanceOf(InvalidNumberError);
-      }
+    it(`throws error when total is ${invalidNumber}`, () => {
+      expect(() => calculatePercentage({ current: 10, total: invalidNumber })).toThrow(
+        InvalidNumberError
+      );
     });
   });
 });
@@ -63,12 +51,9 @@ describe('calculateAverage', () => {
 
   INVALID_NUMBERS.forEach(invalidNumber => {
     it(`throws error when any of the values provided is ${invalidNumber}`, () => {
-      try {
-        expect.assertions(1);
-        calculateAverage([1, 2, invalidNumber]);
-      } catch (err) {
-        expect(err).toBeInstanceOf(InvalidNumberError);
-      }
+      expect(() => calculateAverage([1, 2, invalidNumber])).toThrow(
+        InvalidNumberError
+      );
     });
   });
 });
@@ -80,12 +65,7 @@ describe('round', () => {
 
   INVALID_NUMBERS.forEach(invalidNumber => {
     it(`throws error when the number provided is ${invalidNumber}`, () => {
-      try {
-        expect.assertions(1);
-        round(invalidNumber);
-      } catch (err) {
-        expect(err).toBeInstanceOf(InvalidNumberError);
-      }
+      expect(() => round(invalidNumber)).toThrow(InvalidNumberError);
     });
   });
 });

--- a/dashboard/src/pages/StudyConfPage/forms/shared/TargetingSummary.tsx
+++ b/dashboard/src/pages/StudyConfPage/forms/shared/TargetingSummary.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+/**
+ * Pure renderer for facebook_targeting objects.
+ * Used by both Level.tsx (variables) and Stratum.tsx (strata) for visual consistency.
+ * Returns a readable summary of the targeting data; falls back to key names for unknown properties.
+ */
+export const renderTargetingSummary = (targeting: any) => {
+  if (!targeting || Object.keys(targeting).length === 0) {
+    return <span className="text-gray-400 italic">No targeting data</span>;
+  }
+
+  const parts: string[] = [];
+
+  if (targeting.geo_locations?.cities) {
+    const cities = targeting.geo_locations.cities.slice(0, 3).map((c: any) => c.name || c.key);
+    parts.push(`Locations: ${cities.join(', ')}`);
+  }
+
+  if (targeting.age_min || targeting.age_max) {
+    const minAge = targeting.age_min || '18';
+    const maxAge = targeting.age_max || '65+';
+    parts.push(`Age: ${minAge}–${maxAge}`);
+  }
+
+  if (targeting.genders) {
+    const genderMap: Record<number, string> = { 1: 'M', 2: 'F' };
+    const genders = (targeting.genders || []).map((g: number) => genderMap[g] || g).join(', ');
+    if (genders) parts.push(`Gender: ${genders}`);
+  }
+
+  if (targeting.custom_audiences) {
+    const audNames = targeting.custom_audiences.slice(0, 2).map((a: any) => a.name || a.id);
+    parts.push(`Audiences: ${audNames.join(', ')}`);
+  }
+
+  if (parts.length === 0) {
+    // Fallback: list keys we don't have pretty renderers for
+    const keys = Object.keys(targeting).filter(k => k !== 'targeting_automation');
+    return <span className="text-gray-600 text-sm">{keys.join(', ')}</span>;
+  }
+
+  return <div className="text-sm space-y-1">{parts.map((p, i) => <div key={i}>{p}</div>)}</div>;
+};

--- a/dashboard/src/pages/StudyConfPage/forms/variables/extract.test.ts
+++ b/dashboard/src/pages/StudyConfPage/forms/variables/extract.test.ts
@@ -1,0 +1,104 @@
+import {
+  extractFromAdset,
+  AdsetNotFoundError,
+  PropertyMissingError,
+} from './extract';
+
+const getError = (fn: () => any): Error => {
+  try {
+    fn();
+    throw new Error('Expected function to throw');
+  } catch (err) {
+    return err as Error;
+  }
+};
+
+describe('extract.ts', () => {
+  describe('extractFromAdset', () => {
+    const mockAdset = {
+      id: 'adset-123',
+      name: 'Test Adset',
+      targeting: {
+        geo_locations: { cities: [{ key: 'NG-BA', name: 'Bauchi' }] },
+        age_min: 18,
+        age_max: 65,
+        genders: [1],
+        targeting_automation: 'DEFAULT',
+      },
+    };
+
+    it('should extract requested properties from an adset', () => {
+      const result = extractFromAdset(mockAdset, ['geo_locations', 'age_min', 'age_max']);
+
+      expect(result).toEqual({
+        geo_locations: { cities: [{ key: 'NG-BA', name: 'Bauchi' }] },
+        age_min: 18,
+        age_max: 65,
+        targeting_automation: 'DEFAULT',
+      });
+    });
+
+    it('should include targeting_automation if present, even if not requested', () => {
+      const result = extractFromAdset(mockAdset, ['geo_locations']);
+
+      expect(result).toHaveProperty('targeting_automation', 'DEFAULT');
+    });
+
+    it('should throw AdsetNotFoundError if adset is null', () => {
+      expect(() => {
+        extractFromAdset(null, ['geo_locations']);
+      }).toThrow(AdsetNotFoundError);
+
+      const err = getError(() => extractFromAdset(null, ['geo_locations']));
+      expect(err).toBeInstanceOf(AdsetNotFoundError);
+      expect((err as AdsetNotFoundError).adsetName).toBe('(unknown)');
+    });
+
+    it('should throw AdsetNotFoundError if adset is undefined', () => {
+      expect(() => {
+        extractFromAdset(undefined, ['geo_locations']);
+      }).toThrow(AdsetNotFoundError);
+    });
+
+    it('should throw PropertyMissingError if a requested property is missing', () => {
+      expect(() => {
+        extractFromAdset(mockAdset, ['geo_locations', 'custom_audiences']);
+      }).toThrow(PropertyMissingError);
+
+      const err = getError(() => extractFromAdset(mockAdset, ['custom_audiences']));
+      expect(err).toBeInstanceOf(PropertyMissingError);
+      expect((err as PropertyMissingError).propertyKey).toBe('custom_audiences');
+      expect((err as PropertyMissingError).adsetName).toBe('Test Adset');
+    });
+
+    it('should return empty object for adset with targeting_automation but no requested properties', () => {
+      const minimalAdset = {
+        id: 'adset-456',
+        name: 'Minimal Adset',
+        targeting: {
+          targeting_automation: 'DEFAULT',
+        },
+      };
+
+      const result = extractFromAdset(minimalAdset, []);
+      expect(result).toEqual({ targeting_automation: 'DEFAULT' });
+    });
+  });
+
+  describe('error types', () => {
+    it('AdsetNotFoundError should have correct name and adsetName field', () => {
+      const error = new AdsetNotFoundError('my-adset');
+      expect(error.name).toBe('AdsetNotFoundError');
+      expect(error.adsetName).toBe('my-adset');
+      expect(error.message).toContain('my-adset');
+    });
+
+    it('PropertyMissingError should have correct name and fields', () => {
+      const error = new PropertyMissingError('my-adset', 'geo_locations');
+      expect(error.name).toBe('PropertyMissingError');
+      expect(error.adsetName).toBe('my-adset');
+      expect(error.propertyKey).toBe('geo_locations');
+      expect(error.message).toContain('geo_locations');
+    });
+  });
+});

--- a/dashboard/src/pages/StudyConfPage/forms/variables/extract.ts
+++ b/dashboard/src/pages/StudyConfPage/forms/variables/extract.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure extraction module for facebook_targeting from template adsets.
+ * Typed error handling allows the UI to render specific, actionable messages.
+ * No React dependencies; testable in isolation.
+ */
+
+export class AdsetNotFoundError extends Error {
+  adsetName: string;
+
+  constructor(adsetName: string) {
+    super(`Template adset ${adsetName} not found on Meta`);
+    this.adsetName = adsetName;
+    this.name = 'AdsetNotFoundError';
+  }
+}
+
+export class PropertyMissingError extends Error {
+  adsetName: string;
+  propertyKey: string;
+
+  constructor(adsetName: string, propertyKey: string) {
+    super(`Adset ${adsetName} has no ${propertyKey} property`);
+    this.adsetName = adsetName;
+    this.propertyKey = propertyKey;
+    this.name = 'PropertyMissingError';
+  }
+}
+
+/**
+ * Extract requested properties from an adset's targeting.
+ *
+ * @param adset The adset object from the Meta API response. Must have id and targeting.
+ * @param properties Array of property keys to extract (e.g. ["geo_locations", "age_min"])
+ * @returns Object with extracted targeting properties
+ * @throws AdsetNotFoundError if adset is null or undefined
+ * @throws PropertyMissingError if any requested property is not present on the adset
+ */
+export function extractFromAdset(
+  adset: any | null | undefined,
+  properties: string[]
+): any {
+  if (!adset) {
+    throw new AdsetNotFoundError('(unknown)');
+  }
+
+  const extracted: any = {};
+
+  for (const property of properties) {
+    if (!(property in adset.targeting)) {
+      throw new PropertyMissingError(adset.name || adset.id, property);
+    }
+    extracted[property] = adset.targeting[property];
+  }
+
+  // Always include targeting_automation if present, regardless of properties selection.
+  if (adset.targeting.targeting_automation !== undefined) {
+    extracted.targeting_automation = adset.targeting.targeting_automation;
+  }
+
+  return extracted;
+}


### PR DESCRIPTION
Adds the extraction logic for pulling Facebook targeting properties from adsets and a shared renderer for displaying targeting summaries.