### PR TITLE
feat(dashboard): merge-aware strata generation and staleness detection

### DIFF
--- a/dashboard/src/pages/StudyConfPage/forms/strata/Strata.tsx
+++ b/dashboard/src/pages/StudyConfPage/forms/strata/Strata.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import Stratum from './Stratum';
 import PrimaryButton from '../../../../components/PrimaryButton';
 import SubmitButton from '../../components/SubmitButton';
 import ErrorPlaceholder from '../../../../components/ErrorPlaceholder';
 import useCreateStudyConf from '../../hooks/useCreateStudyConf';
-import { createStrataFromVariables, getFinishQuestionRef } from './strata';
+import { createStrataFromVariables, getFinishQuestionRef, strataStalenessHint } from './strata';
 import { GlobalFormData, Stratum as StratumType } from '../../../../types/conf';
 import { GenericTextInput, TextInputI } from '../../components/TextInput';
 import ConfWrapper from '../../components/ConfWrapper';
@@ -33,11 +33,17 @@ const Strata: React.FC<Props> = ({
   const studySlug = params.studySlug;
 
   const [formData, setFormData] = useState(localData || []);
+  const [finishQuestionRef, setFinishQuestionRef] = useState(getFinishQuestionRef(localData || []));
 
-  const [finishQuestionRef, setFinishQuestionRef] = useState(getFinishQuestionRef(formData));
+  // Resync form state when globalData (variables/strata) changes.
+  // This ensures the Strata page reflects fresh data after navigation.
+  useEffect(() => {
+    setFormData(localData || []);
+    setFinishQuestionRef(getFinishQuestionRef(localData || []));
+  }, [localData]);
 
   const regenerate = () => {
-    const strata = createStrataFromVariables(variables, finishQuestionRef, creatives, audiences);
+    const strata = createStrataFromVariables(variables, finishQuestionRef, creatives, audiences, formData);
     setFormData(strata);
   };
 
@@ -80,8 +86,18 @@ const Strata: React.FC<Props> = ({
     );
   }
 
+  const isStale = strataStalenessHint(variables, formData);
+
   return (
     <ConfWrapper>
+      {isStale && (
+        <div className="mb-4 p-4 bg-blue-50 border border-blue-200 rounded-md">
+          <p className="text-sm text-blue-800">
+            Variables have changed since these strata were saved — click Regenerate to refresh.
+          </p>
+        </div>
+      )}
+
       <div className="py-2 text-left">
         <AdditionalStrataTextInput
           name="finishQuestionRef"
@@ -98,11 +114,11 @@ const Strata: React.FC<Props> = ({
             leftIcon="RefreshIcon"
             onClick={regenerate}
           >
-            Generate
+            Regenerate
           </PrimaryButton>
         </div>
         <span className="ml-4 italic text-gray-700 text-sm">
-          Generates strata from a set of variables
+          Regenerates strata from current variables
         </span>
       </div>
       <form onSubmit={onSubmit}>

--- a/dashboard/src/pages/StudyConfPage/forms/strata/strata.spec.ts
+++ b/dashboard/src/pages/StudyConfPage/forms/strata/strata.spec.ts
@@ -1,4 +1,4 @@
-import { createStrataFromVariables, getFinishQuestionRef } from './strata';
+import { createStrataFromVariables, getFinishQuestionRef, strataStalenessHint } from './strata';
 import { Stratum, Variables, Creatives } from '../../../../types/conf';
 
 describe('createStrataFromVariables', () => {
@@ -484,3 +484,203 @@ describe("getFinishQuestionRef", () => {
 
 
 })
+
+describe('createStrataFromVariables with merge', () => {
+  it('Merge preserves audiences/quota/metadata for existing stratum IDs', () => {
+    const variables: Variables = [
+      {
+        name: 'gender',
+        properties: ['genders'],
+        levels: [
+          { name: 'men', template_campaign: 'foo', template_adset: 'men', facebook_targeting: { 'genders': [1] }, quota: 0.5 },
+          { name: 'women', template_campaign: 'foo', template_adset: 'women', facebook_targeting: { 'genders': [2] }, quota: 0.5 }
+        ]
+      }
+    ];
+
+    const existingStrata: Stratum[] = [
+      {
+        id: 'gender:men',
+        quota: 0.3,
+        creatives: ['creative_A'],
+        audiences: ['audience_1'],
+        excluded_audiences: ['excluded_1'],
+        facebook_targeting: { 'genders': [1] },
+        metadata: { gender: 'men' },
+      }
+    ];
+
+    const strata = createStrataFromVariables(variables, "foo", undefined, undefined, existingStrata);
+
+    expect(strata.length).toBe(2);
+    const menStratum = strata.find(s => s.id === 'gender:men');
+    expect(menStratum?.quota).toBe(0.3);
+    expect(menStratum?.creatives).toEqual(['creative_A']);
+    expect(menStratum?.audiences).toEqual(['audience_1']);
+    expect(menStratum?.excluded_audiences).toEqual(['excluded_1']);
+  });
+
+  it('Drops strata whose IDs no longer exist in the new combination set', () => {
+    const variables: Variables = [
+      {
+        name: 'gender',
+        properties: ['genders'],
+        levels: [
+          { name: 'men', template_campaign: 'foo', template_adset: 'men', facebook_targeting: { 'genders': [1] }, quota: 0.5 }
+        ]
+      }
+    ];
+
+    const existingStrata: Stratum[] = [
+      {
+        id: 'gender:men',
+        quota: 0.5,
+        creatives: ['creative_A'],
+        audiences: [],
+        excluded_audiences: [],
+        facebook_targeting: { 'genders': [1] },
+        metadata: { gender: 'men' },
+      },
+      {
+        id: 'gender:women',
+        quota: 0.5,
+        creatives: ['creative_A'],
+        audiences: [],
+        excluded_audiences: [],
+        facebook_targeting: { 'genders': [2] },
+        metadata: { gender: 'women' },
+      }
+    ];
+
+    const strata = createStrataFromVariables(variables, "foo", undefined, undefined, existingStrata);
+
+    expect(strata.length).toBe(1);
+    expect(strata[0].id).toBe('gender:men');
+  });
+
+  it('Adds new combinations with defaults', () => {
+    const variables: Variables = [
+      {
+        name: 'gender',
+        properties: ['genders'],
+        levels: [
+          { name: 'men', template_campaign: 'foo', template_adset: 'men', facebook_targeting: { 'genders': [1] }, quota: 0.5 },
+          { name: 'women', template_campaign: 'foo', template_adset: 'women', facebook_targeting: { 'genders': [2] }, quota: 0.5 }
+        ]
+      }
+    ];
+
+    const existingStrata: Stratum[] = [
+      {
+        id: 'gender:men',
+        quota: 0.5,
+        creatives: ['creative_A'],
+        audiences: ['audience_1'],
+        excluded_audiences: [],
+        facebook_targeting: { 'genders': [1] },
+        metadata: { gender: 'men' },
+      }
+    ];
+
+    const strata = createStrataFromVariables(variables, "foo", undefined, undefined, existingStrata);
+
+    expect(strata.length).toBe(2);
+    const womenStratum = strata.find(s => s.id === 'gender:women');
+    expect(womenStratum).toBeDefined();
+    expect(womenStratum?.audiences).toEqual([]);
+    expect(womenStratum?.creatives).toEqual([]);
+  });
+});
+
+describe('strataStalenessHint', () => {
+  it('Returns true when a level is added to a variable', () => {
+    const variables: Variables = [
+      {
+        name: 'gender',
+        properties: ['genders'],
+        levels: [
+          { name: 'men', template_campaign: 'foo', template_adset: 'men', facebook_targeting: { 'genders': [1] }, quota: 0.5 },
+          { name: 'women', template_campaign: 'foo', template_adset: 'women', facebook_targeting: { 'genders': [2] }, quota: 0.5 }
+        ]
+      }
+    ];
+
+    const savedStrata: Stratum[] = [
+      {
+        id: 'gender:men',
+        quota: 0.5,
+        creatives: [],
+        audiences: [],
+        excluded_audiences: [],
+        facebook_targeting: { 'genders': [1] },
+        question_targeting: {
+          op: "and",
+          vars: [
+            {
+              op: "equal",
+              vars: [
+                { type: "variable", value: "gender" },
+                { type: "constant", value: "men" }
+              ]
+            },
+            {
+              op: "answered",
+              vars: [
+                { type: "variable", value: "finish_q" }
+              ]
+            }
+          ]
+        },
+        metadata: { gender: 'men' },
+      }
+    ];
+
+    const isStale = strataStalenessHint(variables, savedStrata);
+    expect(isStale).toBe(true);
+  });
+
+  it('Returns false when nothing changed', () => {
+    const variables: Variables = [
+      {
+        name: 'gender',
+        properties: ['genders'],
+        levels: [
+          { name: 'men', template_campaign: 'foo', template_adset: 'men', facebook_targeting: { 'genders': [1] }, quota: 0.5 }
+        ]
+      }
+    ];
+
+    const savedStrata: Stratum[] = [
+      {
+        id: 'gender:men',
+        quota: 0.5,
+        creatives: [],
+        audiences: [],
+        excluded_audiences: [],
+        facebook_targeting: { 'genders': [1] },
+        question_targeting: {
+          op: "and",
+          vars: [
+            {
+              op: "equal",
+              vars: [
+                { type: "variable", value: "gender" },
+                { type: "constant", value: "men" }
+              ]
+            },
+            {
+              op: "answered",
+              vars: [
+                { type: "variable", value: "finish_q" }
+              ]
+            }
+          ]
+        },
+        metadata: { gender: 'men' },
+      }
+    ];
+
+    const isStale = strataStalenessHint(variables, savedStrata);
+    expect(isStale).toBe(false);
+  });
+});

--- a/dashboard/src/pages/StudyConfPage/forms/strata/strata.ts
+++ b/dashboard/src/pages/StudyConfPage/forms/strata/strata.ts
@@ -49,7 +49,13 @@ const cartesianProduct = (a: any[]) => {
   return a.reduce((a, b) => a.flatMap((d: any) => b.map((e: any) => [d, e].flat())));
 }
 
-export const createStrataFromVariables = (variables: Variables, finishQuestionRef?: string, creatives?: Creatives, audiences?: Audiences) => {
+export const createStrataFromVariables = (
+  variables: Variables,
+  finishQuestionRef?: string,
+  creatives?: Creatives,
+  audiences?: Audiences,
+  existingStrata?: Stratum[]
+) => {
   if (!variables.length) return [];
 
   if (!finishQuestionRef) {
@@ -64,7 +70,7 @@ export const createStrataFromVariables = (variables: Variables, finishQuestionRe
       v.levels.map((level: any) => ({ ...level, variableName: v.name }))
     );
 
-  const strata: Stratum[] = cartesianProduct(res)
+  const newStrata: Stratum[] = cartesianProduct(res)
     .map((l: IntermediateLevel[]) => formatGroupProduct(l, finishQuestionRef))
     .map((data: Level) => ({
       audiences: [],
@@ -73,8 +79,72 @@ export const createStrataFromVariables = (variables: Variables, finishQuestionRe
       ...data,
     }));
 
-  return strata
+  // If no existing strata provided, return new strata as-is
+  if (!existingStrata || existingStrata.length === 0) {
+    return newStrata;
+  }
+
+  // Merge by stratum ID: preserve user-edited fields from existing strata,
+  // overwrite derived fields (facebook_targeting) with fresh values
+  const existingById = new Map(existingStrata.map(s => [s.id, s]));
+
+  return newStrata.map(newStratum => {
+    const existing = existingById.get(newStratum.id);
+    if (!existing) {
+      return newStratum;
+    }
+
+    // Preserve user-edited fields: creatives, audiences, excluded_audiences, quota, metadata
+    // Overwrite derived fields: facebook_targeting, question_targeting
+    return {
+      ...newStratum,
+      creatives: existing.creatives,
+      audiences: existing.audiences,
+      excluded_audiences: existing.excluded_audiences,
+      quota: existing.quota,
+      metadata: existing.metadata,
+    };
+  });
 }
+
+export const strataStalenessHint = (variables: Variables, savedStrata?: Stratum[]): boolean => {
+  if (!savedStrata || savedStrata.length === 0) {
+    return variables.length > 0;
+  }
+
+  // Generate what the strata would be from current variables (without merging)
+  // Use a dummy finishQuestionRef if one doesn't exist in savedStrata
+  let finishRef = getFinishQuestionRef(savedStrata);
+  if (!finishRef) {
+    finishRef = "dummy";
+  }
+
+  const freshStrata = createStrataFromVariables(variables, finishRef);
+
+  // Check 1: different set of stratum IDs
+  const savedIds = savedStrata.map(s => s.id);
+  const freshIds = freshStrata.map(s => s.id);
+
+  if (savedIds.length !== freshIds.length) {
+    return true;
+  }
+
+  for (const id of savedIds) {
+    if (!freshIds.includes(id)) {
+      return true;
+    }
+  }
+
+  // Check 2: facebook_targeting changed for any stratum that exists in both
+  for (const savedStratum of savedStrata) {
+    const freshStratum = freshStrata.find(s => s.id === savedStratum.id);
+    if (freshStratum && JSON.stringify(freshStratum.facebook_targeting) !== JSON.stringify(savedStratum.facebook_targeting)) {
+      return true;
+    }
+  }
+
+  return false;
+};
 
 export const getFinishQuestionRef = (strata: Stratum[]): string => {
   const s = strata[0]


### PR DESCRIPTION
Generates strata from variables while preserving user-edited fields, and detects when saved strata are stale relative to current variables.