### PR TITLE
feat(dashboard): add targeting output panel to Stratum rows and Playwright E2E tests

### DIFF
--- a/dashboard/.env.playwright.example
+++ b/dashboard/.env.playwright.example
@@ -1,0 +1,15 @@
+# Auth0 credentials for the test user.
+# Create a user in the vlab-dev.us.auth0.com tenant and set these.
+AUTH0_USERNAME=
+AUTH0_PASSWORD=
+
+# Optional: Facebook credentials to fully automate the OAuth connection.
+# If omitted, the facebook.setup.ts test will pause for manual authentication.
+FACEBOOK_USERNAME=
+FACEBOOK_PASSWORD=
+
+# Use the Auth0-only state (skip the Facebook-connected state).
+# SKIP_FACEBOOK_SETUP=1
+
+# Override the dashboard base URL.
+# PLAYWRIGHT_BASE_URL=https://localhost:3000

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -18,6 +18,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env.playwright
 
 npm-debug.log*
 yarn-debug.log*
@@ -26,4 +27,9 @@ yarn-error.log*
 /cypress/fixtures
 cypress.env.json
 cypress/screenshots/
+
+# Playwright
+/playwright/.auth/
+/test-results/
+
 

--- a/dashboard/e2e/auth.setup.ts
+++ b/dashboard/e2e/auth.setup.ts
@@ -7,7 +7,24 @@ const authFile = path.join(__dirname, '../playwright/.auth/state.json');
 const username = process.env.AUTH0_USERNAME;
 const password = process.env.AUTH0_PASSWORD;
 
-setup('authenticate via Auth0', async ({ page, baseURL }) => {
+function isStateFresh(filePath: string, maxAgeMs: number): boolean {
+  try {
+    const stats = fs.statSync(filePath);
+    return Date.now() - stats.mtimeMs < maxAgeMs;
+  } catch {
+    return false;
+  }
+}
+
+const AUTH_STATE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const forceSetup = process.env.FORCE_AUTH_SETUP === '1';
+
+setup.skip(
+  !forceSetup && isStateFresh(authFile, AUTH_STATE_MAX_AGE_MS),
+  'Auth0 state already exists and is fresh. Delete playwright/.auth/state.json or set FORCE_AUTH_SETUP=1 to re-authenticate.'
+);
+
+setup('authenticate via Auth0', async ({ page }) => {
   if (!username || !password) {
     throw new Error(
       'AUTH0_USERNAME and AUTH0_PASSWORD must be set. ' +
@@ -18,24 +35,22 @@ setup('authenticate via Auth0', async ({ page, baseURL }) => {
   // Ensure the auth directory exists
   fs.mkdirSync(path.dirname(authFile), { recursive: true });
 
-  await page.goto(`${baseURL}/login`);
+  // Dashboard landing page redirects to Auth0.
+  await page.goto('/');
+  await page.locator('.loginbtn').click();
 
-  // The Auth0 React SDK redirects to the universal login page.
-  // Wait for the login form and fill it.
-  await page.waitForSelector('input[name="username"], input[name="email"], input[name="password"]', {
-    timeout: 10000,
-  });
+  // Wait for the Auth0 universal login page.
+  await page.waitForURL(/vlab-dev\.us\.auth0\.com/);
+  await page.locator('input#username, input[name="username"]').waitFor();
+  await page.locator('input#username, input[name="username"]').fill(username);
+  await page.locator('input#password, input[name="password"]').fill(password);
+  await page.locator('button[value=default], button[type="submit"]').click();
 
-  const emailField = page.locator('input[name="username"], input[name="email"]').first();
-  const passwordField = page.locator('input[name="password"]').first();
-
-  await emailField.fill(username);
-  await passwordField.fill(password);
-  await page.locator('button[type="submit"]').first().click();
-
-  // Wait for the dashboard to load after redirect.
-  await expect(page).toHaveURL(/studies/);
-  await expect(page.locator('text=Studies')).toBeVisible();
+  // Wait for redirect back to the dashboard.
+  await page.waitForURL(/https:\/\/localhost:3000\//);
+  // The app creates the user on first login; wait for the authenticated header.
+  await expect(page.getByTestId('user-avatar')).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId('header')).toContainText('Studies');
 
   // Save cookies / local storage so other tests skip the login flow.
   await page.context().storageState({ path: authFile });

--- a/dashboard/e2e/auth.setup.ts
+++ b/dashboard/e2e/auth.setup.ts
@@ -1,0 +1,42 @@
+import { test as setup, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const authFile = path.join(__dirname, '../playwright/.auth/state.json');
+
+const username = process.env.AUTH0_USERNAME;
+const password = process.env.AUTH0_PASSWORD;
+
+setup('authenticate via Auth0', async ({ page, baseURL }) => {
+  if (!username || !password) {
+    throw new Error(
+      'AUTH0_USERNAME and AUTH0_PASSWORD must be set. ' +
+      'Create a user in the Auth0 dev tenant and export the credentials.'
+    );
+  }
+
+  // Ensure the auth directory exists
+  fs.mkdirSync(path.dirname(authFile), { recursive: true });
+
+  await page.goto(`${baseURL}/login`);
+
+  // The Auth0 React SDK redirects to the universal login page.
+  // Wait for the login form and fill it.
+  await page.waitForSelector('input[name="username"], input[name="email"], input[name="password"]', {
+    timeout: 10000,
+  });
+
+  const emailField = page.locator('input[name="username"], input[name="email"]').first();
+  const passwordField = page.locator('input[name="password"]').first();
+
+  await emailField.fill(username);
+  await passwordField.fill(password);
+  await page.locator('button[type="submit"]').first().click();
+
+  // Wait for the dashboard to load after redirect.
+  await expect(page).toHaveURL(/studies/);
+  await expect(page.locator('text=Studies')).toBeVisible();
+
+  // Save cookies / local storage so other tests skip the login flow.
+  await page.context().storageState({ path: authFile });
+});

--- a/dashboard/e2e/facebook.setup.ts
+++ b/dashboard/e2e/facebook.setup.ts
@@ -11,22 +11,44 @@ const facebookAuthFile = path.join(__dirname, '../playwright/.auth/facebook-stat
  * already have a Facebook account connected.
  *
  * If FACEBOOK_USERNAME and FACEBOOK_PASSWORD are set, the OAuth flow is automated.
- * Otherwise, the test pauses for manual authentication.
+ * Otherwise, the test waits for the user to authenticate in the browser window.
+ *
+ * The resulting state is reused for subsequent runs. Delete the state file or set
+ * FORCE_FACEBOOK_SETUP=1 to re-authenticate.
  */
 const facebookUsername = process.env.FACEBOOK_USERNAME;
 const facebookPassword = process.env.FACEBOOK_PASSWORD;
 
+function isStateFresh(filePath: string, maxAgeMs: number): boolean {
+  try {
+    const stats = fs.statSync(filePath);
+    return Date.now() - stats.mtimeMs < maxAgeMs;
+  } catch {
+    return false;
+  }
+}
+
+const FACEBOOK_STATE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const forceSetup = process.env.FORCE_FACEBOOK_SETUP === '1';
+
+setup.skip(
+  !forceSetup && isStateFresh(facebookAuthFile, FACEBOOK_STATE_MAX_AGE_MS),
+  'Facebook state already exists and is fresh. Delete playwright/.auth/facebook-state.json or set FORCE_FACEBOOK_SETUP=1 to re-authenticate.'
+);
+
 setup('connect Facebook account', async ({ page }) => {
+  setup.setTimeout(600_000);
   fs.mkdirSync(path.dirname(facebookAuthFile), { recursive: true });
 
   await page.goto('/accounts');
-  await expect(page.getByText('Connected Accounts')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Connected Accounts' })).toBeVisible();
 
   // Click the new-account button.
   await page.getByTestId('new-account-button').click();
 
-  // Select Facebook from the modal.
-  await page.locator('select[name="authType"]').selectOption('facebook');
+  // Select Facebook from the modal's listbox.
+  await page.getByRole('button', { name: 'Account type Typeform' }).click();
+  await page.getByRole('option', { name: 'Facebook' }).click();
 
   // Click Connect and wait for Facebook OAuth redirect.
   await page.getByRole('button', { name: /connect/i }).click();
@@ -42,14 +64,11 @@ setup('connect Facebook account', async ({ page }) => {
     if (await continueButton.isVisible().catch(() => false)) {
       await continueButton.click();
     }
-  } else {
-    // Pause for manual authentication. The user can log in and approve the app.
-    await page.pause();
   }
 
   // Wait for redirect back to the dashboard with a connected Facebook account.
-  await page.waitForURL(/\/accounts\?type=facebook/);
-  await expect(page.getByText('Facebook')).toBeVisible();
+  await page.waitForURL(/\/accounts\?type=facebook/, { timeout: 600_000 });
+  await expect(page.getByRole('heading', { name: 'Connected Accounts' })).toBeVisible();
 
   // Save the combined state (Auth0 + Facebook cookies).
   await page.context().storageState({ path: facebookAuthFile });

--- a/dashboard/e2e/facebook.setup.ts
+++ b/dashboard/e2e/facebook.setup.ts
@@ -19,12 +19,6 @@ const facebookPassword = process.env.FACEBOOK_PASSWORD;
 setup('connect Facebook account', async ({ page }) => {
   fs.mkdirSync(path.dirname(facebookAuthFile), { recursive: true });
 
-  // Reuse the Auth0 login state.
-  const authStateFile = path.join(__dirname, '../playwright/.auth/state.json');
-  if (!fs.existsSync(authStateFile)) {
-    throw new Error('Auth0 state not found. Run `npx playwright test e2e/auth.setup.ts` first.');
-  }
-
   await page.goto('/accounts');
   await expect(page.getByText('Connected Accounts')).toBeVisible();
 

--- a/dashboard/e2e/facebook.setup.ts
+++ b/dashboard/e2e/facebook.setup.ts
@@ -1,0 +1,62 @@
+import { test as setup, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const facebookAuthFile = path.join(__dirname, '../playwright/.auth/facebook-state.json');
+
+/**
+ * Facebook connection setup.
+ *
+ * Run this once before the variables/strata tests if the test Auth0 user does not
+ * already have a Facebook account connected.
+ *
+ * If FACEBOOK_USERNAME and FACEBOOK_PASSWORD are set, the OAuth flow is automated.
+ * Otherwise, the test pauses for manual authentication.
+ */
+const facebookUsername = process.env.FACEBOOK_USERNAME;
+const facebookPassword = process.env.FACEBOOK_PASSWORD;
+
+setup('connect Facebook account', async ({ page }) => {
+  fs.mkdirSync(path.dirname(facebookAuthFile), { recursive: true });
+
+  // Reuse the Auth0 login state.
+  const authStateFile = path.join(__dirname, '../playwright/.auth/state.json');
+  if (!fs.existsSync(authStateFile)) {
+    throw new Error('Auth0 state not found. Run `npx playwright test e2e/auth.setup.ts` first.');
+  }
+
+  await page.goto('/accounts');
+  await expect(page.getByText('Connected Accounts')).toBeVisible();
+
+  // Click the new-account button.
+  await page.getByTestId('new-account-button').click();
+
+  // Select Facebook from the modal.
+  await page.locator('select[name="authType"]').selectOption('facebook');
+
+  // Click Connect and wait for Facebook OAuth redirect.
+  await page.getByRole('button', { name: /connect/i }).click();
+  await page.waitForURL(/facebook\.com/);
+
+  if (facebookUsername && facebookPassword) {
+    await page.locator('input[name="email"]').fill(facebookUsername);
+    await page.locator('input[name="pass"]').fill(facebookPassword);
+    await page.locator('button[name="login"]').click();
+
+    // Accept any permissions prompt if it appears.
+    const continueButton = page.locator('button[name="__CONFIRM__"], [role="button"]:has-text("Continue")');
+    if (await continueButton.isVisible().catch(() => false)) {
+      await continueButton.click();
+    }
+  } else {
+    // Pause for manual authentication. The user can log in and approve the app.
+    await page.pause();
+  }
+
+  // Wait for redirect back to the dashboard with a connected Facebook account.
+  await page.waitForURL(/\/accounts\?type=facebook/);
+  await expect(page.getByText('Facebook')).toBeVisible();
+
+  // Save the combined state (Auth0 + Facebook cookies).
+  await page.context().storageState({ path: facebookAuthFile });
+});

--- a/dashboard/e2e/variables.spec.ts
+++ b/dashboard/e2e/variables.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
 /**
  * End-to-end test for the Variables → Strata flow.
@@ -6,14 +6,67 @@ import { test, expect } from '@playwright/test';
  * Preconditions:
  *   - Auth0 user is authenticated (via auth.setup.ts)
  *   - A Facebook account is connected (via facebook.setup.ts or manually)
- *   - The connected Facebook account has at least one ad account with a campaign and adset
  *
- * This test exercises the refactor: explicit extraction from Meta, output panels,
- * submit gating, and merge-aware strata regeneration.
+ * The Facebook Graph API responses are mocked so the test does not depend on the
+ * connected account having real ad accounts, campaigns, or adsets. The OAuth
+ * connection itself is real.
  */
+
+const MOCK_AD_ACCOUNT = { id: 'act_123456789', account_id: '123456789', name: 'Mock Ad Account' };
+const MOCK_CAMPAIGN = { id: 'mock-campaign-1', name: 'Mock Campaign' };
+const MOCK_ADSET = {
+  id: 'mock-adset-1',
+  name: 'Mock Adset',
+  targeting: {
+    genders: [1],
+    age_min: 18,
+    age_max: 65,
+  },
+};
+
+function mockFacebookApi(page: Page) {
+  return page.route('https://graph.facebook.com/**', async route => {
+    const url = new URL(route.request().url());
+    const path = url.pathname;
+    const paginated = (data: any[]) => ({ data, paging: { before: '', after: '' } });
+
+    if (path.endsWith('/me/adaccounts')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(paginated([MOCK_AD_ACCOUNT])) });
+      return;
+    }
+    if (path.endsWith('/campaigns')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(paginated([MOCK_CAMPAIGN])) });
+      return;
+    }
+    if (path.endsWith('/adsets')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(paginated([MOCK_ADSET])) });
+      return;
+    }
+
+    await route.continue();
+  });
+}
+
+function mockConfsApi(page: Page) {
+  return page.route(/\/confs$/, async route => {
+    const response = await route.fetch();
+    const body = await response.json();
+    const confs = body.data || body;
+    if (!confs.creatives) {
+      confs.creatives = [];
+    }
+    await route.fulfill({
+      status: response.status(),
+      contentType: response.headers()['content-type'] || 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+}
 
 test.describe('Variables → Strata flow', () => {
   test('extracts targeting from Meta, displays it, and saves variables and strata', async ({ page }) => {
+    await mockFacebookApi(page);
+    await mockConfsApi(page);
     const studyName = `playwright-test-${Date.now()}`;
 
     // 1. Create a new study
@@ -21,12 +74,10 @@ test.describe('Variables → Strata flow', () => {
     await page.getByTestId('new-study-name-input').waitFor();
     await page.getByTestId('new-study-name-input').fill(studyName);
     await page.getByTestId('form-submit-button').click();
-    await page.waitForURL(/\/studies$/);
-    await expect(page.getByText(studyName)).toBeVisible();
+    // Creating a study redirects to its initialization page.
+    await page.waitForURL(/\/studies\/[^/]+\/initialize/);
 
-    // 2. Open the study configuration and go to General
-    await page.getByText(studyName).click();
-    await page.waitForURL(/\/studies\//);
+    // 2. Navigate to General
     await page.getByRole('link', { name: 'General' }).click();
     await page.waitForURL(/\/studies\/.*\/general/);
 
@@ -34,7 +85,7 @@ test.describe('Variables → Strata flow', () => {
     await page.locator('select[name="ad_account"]').waitFor();
     await page.locator('select[name="ad_account"]').selectOption({ index: 1 });
     await page.getByTestId('form-submit-button').click();
-    await expect(page.getByText('General saved')).toBeVisible();
+    await expect(page.getByText('General settings saved').first()).toBeVisible();
 
     // 3. Navigate to Variables
     await page.getByRole('link', { name: 'Variables' }).click();
@@ -51,9 +102,10 @@ test.describe('Variables → Strata flow', () => {
     // Select properties from Meta
     await page.getByTestId('variable-properties-select').selectOption(['genders']);
 
-    // 6. Fill in the level and select an adset
+    // 6. Add a level, fill in its name, and select an adset
+    await page.getByText('Add level').click();
     await page.getByTestId('level-name-input').fill('men');
-    await page.getByTestId('level-adset-select').selectOption({ index: 1 });
+    await page.getByTestId('level-adset-select').selectOption(MOCK_ADSET.id);
 
     // 7. Verify the output panel shows extracted targeting
     await expect(page.getByTestId('level-output-panel')).toBeVisible();
@@ -62,17 +114,17 @@ test.describe('Variables → Strata flow', () => {
 
     // 8. Submit variables
     await page.getByTestId('form-submit-button').click();
-    await expect(page.getByText('Variables saved')).toBeVisible();
+    await expect(page.getByText('Variables saved').first()).toBeVisible();
 
     // 9. Navigate to Strata
     await page.getByRole('link', { name: 'Strata' }).click();
     await page.waitForURL(/\/studies\/.*\/strata/);
 
-    // 10. Regenerate strata if stale
+    // 10. Fill finish question ref and regenerate strata
+    await page.locator('input[name="finishQuestionRef"]').fill('finish');
     const regenerateButton = page.getByTestId('regenerate-strata-button');
-    if (await regenerateButton.isVisible()) {
-      await regenerateButton.click();
-    }
+    await expect(regenerateButton).toBeVisible();
+    await regenerateButton.click();
 
     // 11. Verify stratum output panel shows the merged targeting
     await expect(page.getByTestId('stratum-output-panel').first()).toBeVisible();
@@ -80,6 +132,6 @@ test.describe('Variables → Strata flow', () => {
 
     // 12. Submit strata
     await page.getByTestId('form-submit-button').click();
-    await expect(page.getByText('Strata saved')).toBeVisible();
+    await expect(page.getByText('Strata saved').first()).toBeVisible();
   });
 });

--- a/dashboard/e2e/variables.spec.ts
+++ b/dashboard/e2e/variables.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * End-to-end test for the Variables → Strata flow.
+ *
+ * Preconditions:
+ *   - Auth0 user is authenticated (via auth.setup.ts)
+ *   - A Facebook account is connected (via facebook.setup.ts or manually)
+ *   - The connected Facebook account has at least one ad account with a campaign and adset
+ *
+ * This test exercises the refactor: explicit extraction from Meta, output panels,
+ * submit gating, and merge-aware strata regeneration.
+ */
+
+test.describe('Variables → Strata flow', () => {
+  test('extracts targeting from Meta, displays it, and saves variables and strata', async ({ page }) => {
+    const studyName = `playwright-test-${Date.now()}`;
+
+    // 1. Create a new study
+    await page.goto('/new-study');
+    await page.getByTestId('new-study-name-input').waitFor();
+    await page.getByTestId('new-study-name-input').fill(studyName);
+    await page.getByTestId('form-submit-button').click();
+    await page.waitForURL(/\/studies$/);
+    await expect(page.getByText(studyName)).toBeVisible();
+
+    // 2. Open the study configuration and go to General
+    await page.getByText(studyName).click();
+    await page.waitForURL(/\/studies\//);
+    await page.getByRole('link', { name: 'General' }).click();
+    await page.waitForURL(/\/studies\/.*\/general/);
+
+    // Select an ad account and save
+    await page.locator('select[name="ad_account"]').waitFor();
+    await page.locator('select[name="ad_account"]').selectOption({ index: 1 });
+    await page.getByTestId('form-submit-button').click();
+    await expect(page.getByText('General saved')).toBeVisible();
+
+    // 3. Navigate to Variables
+    await page.getByRole('link', { name: 'Variables' }).click();
+    await page.waitForURL(/\/studies\/.*\/variables/);
+
+    // 4. Select a template campaign
+    await page.getByTestId('template-campaign-select').waitFor();
+    await page.getByTestId('template-campaign-select').selectOption({ index: 1 });
+    await expect(page.getByTestId('refresh-from-meta-button')).toBeVisible();
+
+    // 5. Fill in the variable
+    await page.getByTestId('variable-name-input').fill('gender');
+
+    // Select properties from Meta
+    await page.getByTestId('variable-properties-select').selectOption(['genders']);
+
+    // 6. Fill in the level and select an adset
+    await page.getByTestId('level-name-input').fill('men');
+    await page.getByTestId('level-adset-select').selectOption({ index: 1 });
+
+    // 7. Verify the output panel shows extracted targeting
+    await expect(page.getByTestId('level-output-panel')).toBeVisible();
+    await expect(page.getByTestId('level-targeting-summary')).not.toHaveText('No targeting data');
+    await expect(page.getByText('Last extracted')).toBeVisible();
+
+    // 8. Submit variables
+    await page.getByTestId('form-submit-button').click();
+    await expect(page.getByText('Variables saved')).toBeVisible();
+
+    // 9. Navigate to Strata
+    await page.getByRole('link', { name: 'Strata' }).click();
+    await page.waitForURL(/\/studies\/.*\/strata/);
+
+    // 10. Regenerate strata if stale
+    const regenerateButton = page.getByTestId('regenerate-strata-button');
+    if (await regenerateButton.isVisible()) {
+      await regenerateButton.click();
+    }
+
+    // 11. Verify stratum output panel shows the merged targeting
+    await expect(page.getByTestId('stratum-output-panel').first()).toBeVisible();
+    await expect(page.getByTestId('stratum-targeting-summary').first()).not.toHaveText('No targeting data');
+
+    // 12. Submit strata
+    await page.getByTestId('form-submit-button').click();
+    await expect(page.getByText('Strata saved')).toBeVisible();
+  });
+});

--- a/dashboard/playwright.config.ts
+++ b/dashboard/playwright.config.ts
@@ -23,7 +23,16 @@ export default defineConfig({
   },
 
   projects: [
-    { name: 'setup', testMatch: /.*\.setup\.ts/ },
+    // Creates playwright/.auth/state.json
+    { name: 'setup', testMatch: /auth\.setup\.ts/ },
+    // Uses the Auth0 state and creates playwright/.auth/facebook-state.json
+    {
+      name: 'facebook-setup',
+      testMatch: /facebook\.setup\.ts/,
+      dependencies: ['setup'],
+      use: { storageState: 'playwright/.auth/state.json' },
+    },
+    // Runs the end-to-end tests using the combined state.
     {
       name: 'chromium',
       use: {
@@ -32,7 +41,7 @@ export default defineConfig({
           ? 'playwright/.auth/state.json'
           : 'playwright/.auth/facebook-state.json',
       },
-      dependencies: ['setup'],
+      dependencies: ['facebook-setup'],
     },
   ],
 

--- a/dashboard/playwright.config.ts
+++ b/dashboard/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for local end-to-end testing of the VLAB dashboard.
+ *
+ * Assumes:
+ *   - API dev server is running at http://localhost:8080 (see api/Makefile)
+ *   - Dashboard dev server is running at https://localhost:3000 (npm start)
+ *   - HTTPS cert is self-signed (ignoreHTTPSErrors is enabled)
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'https://localhost:3000',
+    ignoreHTTPSErrors: true,
+    trace: 'on-first-retry',
+    video: 'on-first-retry',
+  },
+
+  projects: [
+    { name: 'setup', testMatch: /.*\.setup\.ts/ },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: process.env.SKIP_FACEBOOK_SETUP
+          ? 'playwright/.auth/state.json'
+          : 'playwright/.auth/facebook-state.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+
+  expect: {
+    timeout: 10000,
+  },
+});

--- a/dashboard/src/pages/NewStudyPage/CreateStudy.tsx
+++ b/dashboard/src/pages/NewStudyPage/CreateStudy.tsx
@@ -48,6 +48,7 @@ const CreateStudy: React.FC<any> = () => {
               handleChange={handleChange}
               placeholder="E.g example-fly"
               value={formData.name}
+              data-testid="new-study-name-input"
             />
             <div className="p-6 text-right">
               <PrimaryButton

--- a/dashboard/src/pages/StudyConfPage/components/MultiSelect.tsx
+++ b/dashboard/src/pages/StudyConfPage/components/MultiSelect.tsx
@@ -19,6 +19,7 @@ interface MultiSelectProps<T> {
   handleMultiSelectChange: (selectedValues: string[], name: string) => void;
   value: string[];
   label: string;
+  'data-testid'?: string;
 }
 
 export type MultiSelectI<T = any> = React.FC<MultiSelectProps<T>>
@@ -29,6 +30,7 @@ export const GenericMultiSelect: MultiSelectI = ({
   handleMultiSelectChange,
   value,
   label,
+  'data-testid': testId,
 }) => {
   const onChange = (e: any) => {
     const selected = Array.from(e.target.selectedOptions).map(
@@ -46,6 +48,7 @@ export const GenericMultiSelect: MultiSelectI = ({
         multiple
         value={value}
         onChange={onChange}
+        data-testid={testId}
         className="w-4/5 block shadow-sm sm:text-sm rounded-md"
       >
         {options.map((option: SelectOption, i: number) => (

--- a/dashboard/src/pages/StudyConfPage/components/SubmitButton.tsx
+++ b/dashboard/src/pages/StudyConfPage/components/SubmitButton.tsx
@@ -6,6 +6,7 @@ const SubmitButton = ({ isLoading }: { isLoading: boolean }) => {
       <PrimaryButton
         leftIcon="CheckCircleIcon"
         type="submit"
+        testId="form-submit-button"
         loading={isLoading}
       >
         Next

--- a/dashboard/src/pages/StudyConfPage/components/TemplateCampaignWrapper.tsx
+++ b/dashboard/src/pages/StudyConfPage/components/TemplateCampaignWrapper.tsx
@@ -90,6 +90,7 @@ export const TemplateCampaignWrapper: React.FC<Props> = ({
           options={campaignOptions}
           handleChange={handleChange}
           value={templateCampaign}
+          data-testid="template-campaign-select"
         ></Select>
         <div className="flex w-full h-0.5 mr-4 my-10 rounded-md bg-gray-400"></div>
 

--- a/dashboard/src/pages/StudyConfPage/forms/strata/Strata.tsx
+++ b/dashboard/src/pages/StudyConfPage/forms/strata/Strata.tsx
@@ -113,6 +113,7 @@ const Strata: React.FC<Props> = ({
             type="button"
             leftIcon="RefreshIcon"
             onClick={regenerate}
+            testId="regenerate-strata-button"
           >
             Regenerate
           </PrimaryButton>

--- a/dashboard/src/pages/StudyConfPage/forms/strata/Stratum.tsx
+++ b/dashboard/src/pages/StudyConfPage/forms/strata/Stratum.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { GenericTextInput, TextInputI } from '../../components/TextInput';
 import { GenericMultiSelect, MultiSelectI } from '../../components/MultiSelect';
 import { Stratum as FormData, Creative as CreativeType, Audience as AudienceType } from '../../../../types/conf';
+import { renderTargetingSummary } from '../shared/TargetingSummary';
 
 const TextInput = GenericTextInput as TextInputI<FormData>;
 const MultiSelect = GenericMultiSelect as MultiSelectI<FormData>;
@@ -12,6 +13,7 @@ const Stratum: React.FC<{
   audiences: AudienceType[];
   onChange: (e: any) => void;
 }> = ({ stratum, onChange, creatives, audiences }) => {
+  const [showRawJson, setShowRawJson] = useState(false);
 
   const handleMultiSelectChange = (selected: string[], name: string) => {
     onChange({ target: { name, value: selected } });
@@ -92,6 +94,39 @@ const Stratum: React.FC<{
           </div>
         </div>
       )}
+
+      {/* Output panel */}
+      <div className="mt-3 p-3 bg-gray-50 border border-gray-200 rounded">
+        <div className="text-xs font-semibold text-gray-600 mb-2">Output</div>
+
+        {/* Targeting summary */}
+        <div className="text-sm mb-3">
+          <div className="font-semibold text-gray-700 mb-1">Facebook Targeting:</div>
+          {renderTargetingSummary(stratum.facebook_targeting)}
+        </div>
+
+        {/* Expandable raw JSON */}
+        <button
+          type="button"
+          onClick={() => setShowRawJson(!showRawJson)}
+          className="text-xs text-blue-600 hover:underline mb-2"
+        >
+          {showRawJson ? '▼ Hide JSON' : '▶ Show JSON'}
+        </button>
+        {showRawJson && (
+          <pre className="bg-white p-2 rounded border border-gray-300 text-xs overflow-auto max-h-40 mb-3">
+            {JSON.stringify(stratum.facebook_targeting, null, 2)}
+          </pre>
+        )}
+
+        {/* Compact summary of per-stratum edits */}
+        <div className="text-xs text-gray-600 space-y-1">
+          <div>Creatives: {stratum.creatives?.length || 0}</div>
+          <div>Audiences: {stratum.audiences?.length || 0}</div>
+          <div>Excluded Audiences: {stratum.excluded_audiences?.length || 0}</div>
+          <div>Quota: {stratum.quota || '—'}</div>
+        </div>
+      </div>
 
       <div className="w-4/5 h-0.5 mr-8 my-6 rounded-md bg-gray-400"></div>
     </li>

--- a/dashboard/src/pages/StudyConfPage/forms/strata/Stratum.tsx
+++ b/dashboard/src/pages/StudyConfPage/forms/strata/Stratum.tsx
@@ -96,11 +96,11 @@ const Stratum: React.FC<{
       )}
 
       {/* Output panel */}
-      <div className="mt-3 p-3 bg-gray-50 border border-gray-200 rounded">
+      <div className="mt-3 p-3 bg-gray-50 border border-gray-200 rounded" data-testid="stratum-output-panel">
         <div className="text-xs font-semibold text-gray-600 mb-2">Output</div>
 
         {/* Targeting summary */}
-        <div className="text-sm mb-3">
+        <div className="text-sm mb-3" data-testid="stratum-targeting-summary">
           <div className="font-semibold text-gray-700 mb-1">Facebook Targeting:</div>
           {renderTargetingSummary(stratum.facebook_targeting)}
         </div>
@@ -109,6 +109,7 @@ const Stratum: React.FC<{
         <button
           type="button"
           onClick={() => setShowRawJson(!showRawJson)}
+          data-testid="stratum-toggle-json"
           className="text-xs text-blue-600 hover:underline mb-2"
         >
           {showRawJson ? '▼ Hide JSON' : '▶ Show JSON'}

--- a/dashboard/src/pages/StudyConfPage/forms/variables/Level.tsx
+++ b/dashboard/src/pages/StudyConfPage/forms/variables/Level.tsx
@@ -82,6 +82,7 @@ const Level: React.FC<Props> = ({
           autoComplete="on"
           placeholder="Give your level a name"
           value={data.name}
+          data-testid="level-name-input"
         />
         <Select
           name="template_adset"
@@ -89,6 +90,7 @@ const Level: React.FC<Props> = ({
           handleChange={onAdsetChange}
           value={data.template_adset}
           getValue={(o: any) => o.id}
+          data-testid="level-adset-select"
         ></Select>
         <TextInput
           name="quota"
@@ -99,7 +101,7 @@ const Level: React.FC<Props> = ({
 
         {/* Error display */}
         {error && (
-          <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded text-sm text-red-700">
+          <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded text-sm text-red-700" data-testid="level-error">
             {error.kind === 'adset_not_found' ? (
               <div>
                 Template adset <strong>{error.adsetName}</strong> not found on Meta — pick a different
@@ -114,14 +116,15 @@ const Level: React.FC<Props> = ({
         )}
 
         {/* Output panel */}
-        <div className="mt-3 p-3 bg-gray-50 border border-gray-200 rounded">
+        <div className="mt-3 p-3 bg-gray-50 border border-gray-200 rounded" data-testid="level-output-panel">
           <div className="text-xs font-semibold text-gray-600 mb-2">Output</div>
-          <div className="text-sm mb-2">
+          <div className="text-sm mb-2" data-testid="level-targeting-summary">
             {renderTargetingSummary(data.facebook_targeting)}
           </div>
           <button
             type="button"
             onClick={() => setShowRawJson(!showRawJson)}
+            data-testid="level-toggle-json"
             className="text-xs text-blue-600 hover:underline mb-2"
           >
             {showRawJson ? '▼ Hide JSON' : '▶ Show JSON'}

--- a/dashboard/src/pages/StudyConfPage/forms/variables/Variable.tsx
+++ b/dashboard/src/pages/StudyConfPage/forms/variables/Variable.tsx
@@ -145,6 +145,7 @@ const Variable: React.FC<Props> = ({
         autoComplete="on"
         placeholder="Give your variable a name"
         value={data.name}
+        data-testid="variable-name-input"
       />
       <MultiSelect
         name="properties"
@@ -152,6 +153,7 @@ const Variable: React.FC<Props> = ({
         handleMultiSelectChange={handleMultiSelectChange}
         value={data.properties}
         label="Select a set of properties from Facebook"
+        data-testid="variable-properties-select"
       ></MultiSelect>
       <LevelList
         Element={Level}

--- a/dashboard/src/pages/StudyConfPage/forms/variables/Variables.tsx
+++ b/dashboard/src/pages/StudyConfPage/forms/variables/Variables.tsx
@@ -144,6 +144,7 @@ const Variables: React.FC<Props> = ({
             type="button"
             onClick={handleRefreshFromMeta}
             disabled={isRefreshing}
+            data-testid="refresh-from-meta-button"
             className="px-4 py-2 bg-blue-600 text-white rounded font-medium hover:bg-blue-700 disabled:bg-gray-400"
           >
             {isRefreshing ? 'Refreshing...' : 'Refresh from Meta'}


### PR DESCRIPTION
Adds an output panel to each stratum row showing merged Facebook targeting, and adds Playwright E2E tests for the Variables → Strata flow with reusable auth state.