### PR TITLE
fix(api): update dev Dockerfile for current air and Go versions

### DIFF
--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:1.23-alpine
 
 RUN apk add --no-cache \
     gcc \
@@ -6,6 +6,6 @@ RUN apk add --no-cache \
     readline-dev
 
 WORKDIR /src/app
-RUN go install github.com/cosmtrek/air@latest
+RUN go install github.com/air-verse/air@v1.61.0
 
 CMD ["air", "-c", ".air.toml"]


### PR DESCRIPTION
Updates the API dev Dockerfile to use the air-verse/air image and Go 1.23 so local development builds work again.