### PR TITLE
fix(adopt): pair each creative with its own destination in experiments

### DIFF
--- a/adopt/README.md
+++ b/adopt/README.md
@@ -1,5 +1,45 @@
 # adopt
 
+Core service for managing Virtual Lab studies: campaign orchestration, creative
+management, and publishing ads to Facebook.
+
+## Destination experiments
+
+A study's **destinations** are the places a respondent can land after clicking an
+ad — for Messenger, a `FlyMessengerDestination` naming the survey's
+`initial_shortcode`. Each creative names the destination it belongs to via its
+own `destination` field.
+
+A `SimpleRecruitment` study runs one campaign. A
+`DestinationRecruitmentExperiment` instead runs **one campaign per destination**,
+each an arm of the experiment, with `budget_per_arm` and `max_sample_per_arm`
+applied to each. The arm a campaign represents is identified by matching a
+destination name against the campaign name.
+
+### Creative → destination pairing
+
+`pair_creatives_with_destinations` (`adopt/marketing.py`) selects the creatives
+belonging to the current arm and pairs each one with the destination its own
+config names. `adset_instructions` publishes from those pairs.
+
+The invariant is that **a creative is only ever published with the destination it
+names** — never another creative's. This matters because the destination's
+`initial_shortcode` is baked into the ad's referral `ref` at publish time
+(`make_ref` → `make_welcome_message`), and the bot reads that ref to decide which
+survey the respondent enters. A mispaired creative silently recruits people into
+the wrong arm's survey, and the only way to correct it is to republish the ad.
+
+The pairing is returned as `(creative, destination)` tuples rather than two
+parallel lists. This is deliberate: an earlier implementation filtered the
+creatives per arm but built the destinations from the unfiltered list and joined
+them with `zip`, which truncates to the shorter input rather than failing. Every
+arm after the leading one silently inherited the leading arm's destinations, and
+because nothing raised, it went unnoticed until a study large enough to show it
+in the response data. Pairing into tuples makes the two impossible to
+misalign.
+
+`test_marketing.py` covers this with contiguous, interleaved, and unequal-sized
+arm orderings — ordering must never influence the result.
 
 ## Configuration
 

--- a/adopt/adopt/marketing.py
+++ b/adopt/adopt/marketing.py
@@ -487,34 +487,48 @@ def create_creative(
     raise Exception(f"destination is not a proper type: {destination}")
 
 
-def adset_instructions(
-    study: StudyConf, state: CampaignState, stratum: Stratum, budget: float
-) -> Tuple[AdSet, List[Ad]]:
-    stratum_creatives = stratum.creatives
+def pair_creatives_with_destinations(
+    study: StudyConf, stratum: Stratum, campaign_name: str
+) -> List[Tuple[CreativeConf, DestinationConf]]:
+    """Pair every creative with the destination its own config names.
+
+    In a destination experiment each campaign is one arm of the experiment,
+    so only the creatives assigned to that arm belong in it.
+
+    The pairing is built as tuples rather than by zipping two separately
+    derived lists. A previous version filtered the creatives but built the
+    destinations from the unfiltered list and let zip() truncate to the
+    shorter one, so every arm after the first silently inherited the
+    leading arm's destinations. Keeping each creative and its destination
+    in a single tuple makes that class of mistake unrepresentable.
+    """
+    creatives = stratum.creatives
 
     if isinstance(study.recruitment, DestinationRecruitmentExperiment):
         try:
             destination = next(
-                d for d in study.recruitment.destinations if d in state.campaign_name
+                d for d in study.recruitment.destinations if d in campaign_name
             )
         except StopIteration:
             raise Exception(
-                f"Could not find destination for campaign_name {state.campaign_name}"
+                f"Could not find destination for campaign_name {campaign_name}"
                 " in recruitment destination experiment."
             )
 
-        stratum_creatives = [
-            c for c in stratum_creatives if c.destination == destination
-        ]
+        creatives = [c for c in creatives if c.destination == destination]
 
-    destinations = [get_destination_for_creative(study, c) for c in stratum.creatives]
+    return [(c, get_destination_for_creative(study, c)) for c in creatives]
 
-    creatives = [
-        create_creative(study, stratum, c, d)
-        for d, c in zip(destinations, stratum_creatives)
-    ]
 
-    if isinstance(destinations[0], AppDestination):
+def adset_instructions(
+    study: StudyConf, state: CampaignState, stratum: Stratum, budget: float
+) -> Tuple[AdSet, List[Ad]]:
+    pairs = pair_creatives_with_destinations(study, stratum, state.campaign_name)
+
+    destinations = [d for _, d in pairs]
+    creatives = [create_creative(study, stratum, c, d) for c, d in pairs]
+
+    if destinations and isinstance(destinations[0], AppDestination):
         # TODO: assert all destinations are the same
         # and raise an exception if not the case
 

--- a/adopt/adopt/test_marketing.py
+++ b/adopt/adopt/test_marketing.py
@@ -1,5 +1,6 @@
 import json
 import random
+from datetime import datetime
 from typing import TypeVar
 
 import pytest
@@ -13,18 +14,24 @@ from .marketing import (
     make_ref,
     manage_aud,
     messenger_call_to_action,
+    pair_creatives_with_destinations,
     web_call_to_action,
 )
 from .study_conf import (
     Audience,
     AudienceConf,
     CreativeConf,
+    DestinationRecruitmentExperiment,
     FlyMessengerDestination,
+    GeneralConf,
     InvalidConfigError,
     Lookalike,
     LookalikeAudience,
     LookalikeSpec,
     Partitioning,
+    Stratum,
+    StudyConf,
+    UserInfo,
 )
 
 T = TypeVar("T")
@@ -505,3 +512,151 @@ def test_create_creative_from_template_photo_web():
     assert link_data["image_hash"] == template["object_story_spec"]["photo_data"]["image_hash"]
     assert link_data["message"] == template["object_story_spec"]["photo_data"]["caption"]
     assert link_data["link"] == link
+
+
+# ---------------------------------------------------------------------------
+# Destination experiments: every creative must get its OWN destination.
+#
+# Regression cover for the pairing bug introduced in 4ec9eff6 (Feb 2024) and
+# found in production in Jul 2026: the creatives were filtered per arm but the
+# destinations were not, and zip() truncated to the shorter list. Every arm
+# after the leading one silently published with the leading arm's shortcode.
+# ---------------------------------------------------------------------------
+
+
+def _messenger_dest(name, shortcode):
+    return FlyMessengerDestination(
+        type="messenger",
+        name=name,
+        initial_shortcode=shortcode,
+        welcome_message="Welcome!",
+        button_text="OK",
+    )
+
+
+def _creative(name, destination):
+    return CreativeConf(destination=destination, name=name, template={})
+
+
+def _destination_experiment_study(destinations, creatives):
+    return StudyConf(
+        id="study-1",
+        user=UserInfo(survey_user="user", token="token"),
+        general=GeneralConf(
+            name="test-study",
+            credentials_key="page-1",
+            credentials_entity="facebook_page",
+            ad_account="act_1",
+            opt_window=48,
+        ),
+        destinations=destinations,
+        audiences=[],
+        creatives=creatives,
+        strata=[],
+        recruitment=DestinationRecruitmentExperiment(
+            ad_campaign_name_base="test-campaign",
+            objective="OUTCOME_ENGAGEMENT",
+            optimization_goal="CONVERSATIONS",
+            destination_type="MESSENGER",
+            min_budget=1,
+            budget_per_arm=100,
+            max_sample_per_arm=100,
+            start_date=datetime(2026, 7, 1),
+            end_date=datetime(2026, 8, 1),
+            destinations=[d.name for d in destinations],
+        ),
+    )
+
+
+def _stratum(creatives):
+    return Stratum(
+        id="stratum-1",
+        quota=1.0,
+        creatives=creatives,
+        facebook_targeting={},
+        metadata={},
+    )
+
+
+def _shortcodes(pairs):
+    return [d.initial_shortcode for _, d in pairs]
+
+
+def test_pairing_each_arm_gets_own_destination_when_arms_are_contiguous():
+    """The exact production scenario (OWIS Nigeria, Jul 2026).
+
+    Four arm-A creatives occupy positions 0-3 and four arm-B creatives
+    positions 4-7. Under the bug, arm B's campaign zipped its 4 creatives
+    against destinations[0:4] -- all arm A -- and published every ad with
+    arm A's shortcode. Arm A looked correct purely by ordering luck.
+    """
+    dest_a = _messenger_dest("Arm A", "shortcode_a")
+    dest_b = _messenger_dest("Arm B", "shortcode_b")
+
+    creatives = [_creative(f"a{i}", "Arm A") for i in range(4)]
+    creatives += [_creative(f"b{i}", "Arm B") for i in range(4)]
+
+    study = _destination_experiment_study([dest_a, dest_b], creatives)
+    stratum = _stratum(creatives)
+
+    pairs_b = pair_creatives_with_destinations(study, stratum, "test-campaign-Arm B")
+    assert [c.name for c, _ in pairs_b] == ["b0", "b1", "b2", "b3"]
+    assert _shortcodes(pairs_b) == ["shortcode_b"] * 4
+
+    pairs_a = pair_creatives_with_destinations(study, stratum, "test-campaign-Arm A")
+    assert [c.name for c, _ in pairs_a] == ["a0", "a1", "a2", "a3"]
+    assert _shortcodes(pairs_a) == ["shortcode_a"] * 4
+
+
+def test_pairing_is_independent_of_creative_ordering():
+    """Interleaved ordering (the Ghana pilots) must pair correctly too.
+
+    With arms interleaved the bug scrambled BOTH arms rather than
+    collapsing one, so ordering must not influence the result at all.
+    """
+    dest_a = _messenger_dest("Arm A", "shortcode_a")
+    dest_b = _messenger_dest("Arm B", "shortcode_b")
+
+    creatives = []
+    for i in range(4):
+        creatives.append(_creative(f"a{i}", "Arm A"))
+        creatives.append(_creative(f"b{i}", "Arm B"))
+
+    study = _destination_experiment_study([dest_a, dest_b], creatives)
+    stratum = _stratum(creatives)
+
+    for name, shortcode in [("Arm A", "shortcode_a"), ("Arm B", "shortcode_b")]:
+        pairs = pair_creatives_with_destinations(
+            study, stratum, f"test-campaign-{name}"
+        )
+        assert len(pairs) == 4
+        assert _shortcodes(pairs) == [shortcode] * 4
+        assert all(c.destination == name for c, _ in pairs)
+
+
+def test_pairing_holds_when_arms_have_different_creative_counts():
+    """Unequal arm sizes are where a truncating zip does the most damage."""
+    dest_a = _messenger_dest("Arm A", "shortcode_a")
+    dest_b = _messenger_dest("Arm B", "shortcode_b")
+
+    creatives = [_creative(f"a{i}", "Arm A") for i in range(6)]
+    creatives += [_creative(f"b{i}", "Arm B") for i in range(2)]
+
+    study = _destination_experiment_study([dest_a, dest_b], creatives)
+    stratum = _stratum(creatives)
+
+    pairs_b = pair_creatives_with_destinations(study, stratum, "test-campaign-Arm B")
+    assert _shortcodes(pairs_b) == ["shortcode_b"] * 2
+
+    pairs_a = pair_creatives_with_destinations(study, stratum, "test-campaign-Arm A")
+    assert _shortcodes(pairs_a) == ["shortcode_a"] * 6
+
+
+def test_pairing_raises_when_campaign_matches_no_destination():
+    dest_a = _messenger_dest("Arm A", "shortcode_a")
+    creatives = [_creative("a0", "Arm A")]
+    study = _destination_experiment_study([dest_a], creatives)
+    stratum = _stratum(creatives)
+
+    with pytest.raises(Exception, match="Could not find destination"):
+        pair_creatives_with_destinations(study, stratum, "campaign-with-no-arm")


### PR DESCRIPTION
## The bug

In a `DestinationRecruitmentExperiment`, `adset_instructions` filtered the stratum's creatives down to the current arm but built the `destinations` list from the **unfiltered** `stratum.creatives`, then joined the two with `zip()`. `zip` truncates to the shorter input rather than raising, so each arm was paired with the destinations of the first N creatives in the array instead of its own. Only the arm whose creatives lead the array came out correct; every other arm silently inherited that arm's destinations.

Introduced in `4ec9eff6` (2024-02-18), which added the per-arm filtering and updated the zip's creative list but not the destination list.

The destination's `initial_shortcode` is baked into the ad's referral `ref` at publish time, so this published live ads that recruited respondents into the wrong arm's survey with no error anywhere. Found in production in an 8-creative, 2-arm study where all 8 ads carried the first arm's shortcode and the second arm received no traffic at all.

## The fix

Extract the selection and pairing into a pure function, `pair_creatives_with_destinations`, returning `(creative, destination)` tuples so the two cannot drift apart. Guard the now-possible empty-arm case before indexing `destinations[0]`.

## Tests

Test coverage for this path did not exist, which is why a one-word error survived 2.5 years. Adds regression tests over contiguous, interleaved and unequal-sized arm orderings; all three fail against the previous implementation.

## Deploy note

The fix self-heals already-published ads: the ref lives in `url_tags` and the welcome message inside `object_story_spec`/`asset_feed_spec`, and `update_ad` (`adopt/facebook/reconciliation.py`) compares exactly those fields — so the next `adopt-ads` cron tick after deploy flags a creative mismatch and pushes a full ad update. Respondents already recruited into the wrong arm remain misattributed.

Also documents destination experiments and the pairing invariant in `adopt/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)