### PR TITLE
fix(adopt): declare the Facebook field contract, stop two rewrite loops

### DIFF
--- a/adopt/README.md
+++ b/adopt/README.md
@@ -61,6 +61,11 @@ field, Facebook returns something that does not match, we rewrite, forever:
   These are hand-written, since a normaliser encodes what "the same" means for
   a field and no probe can infer that.
 
+One rule needs no declaration: if we ask for an **empty** value and Facebook
+omits the key, that is agreement, not a difference. Facebook elides empty
+values instead of echoing them. Asking for something non-empty and not seeing
+it is still a difference, so adding an audience is never swallowed.
+
 An **undeclared** nested drop is still treated as a difference, deliberately.
 A real change that must be applied — converting a creative from `photo_data`
 to `link_data`, say — looks identical in the data to a field Facebook silently
@@ -77,9 +82,10 @@ poetry run adopt-probe <study-id-or-name> --update   # rewrite DROPPED
 ```
 
 The probe builds the creative and adset a study's config asks for, fetches the
-live ones, and classifies every field path. It reports ads and adsets
-separately, since they are compared in opposite argument orders — see
-`planning/field-contract.md`. Verdicts:
+live ones, and classifies every field path. Ads and adsets are reported
+separately but compared the same way — desired first, the order `_eq` requires
+so that Facebook's server-added fields are ignored rather than mistaken for
+drift. Verdicts:
 
 | verdict | meaning |
 |---|---|

--- a/adopt/README.md
+++ b/adopt/README.md
@@ -98,6 +98,13 @@ It exits non-zero when the contract and Facebook disagree, so it can gate a
 deploy. `--update` rewrites the `DROPPED` block in place, stamped with today's
 date; review it as a normal git diff.
 
+**Point it at active studies.** `end_time` is a rolling 48-hour window recomputed
+every run, so an inactive study's adsets are always "behind" and the report is
+never clean. That diff means nothing. And read `--update` output before trusting
+it: a genuine one-time change — a setting we started sending after those adsets
+were built — looks identical to a dropped field. `planning/field-contract.md`
+has a worked example.
+
 It is read-only by default because it points at ads spending real money.
 
 Background on the incident that motivated this: `planning/field-contract.md`.

--- a/adopt/README.md
+++ b/adopt/README.md
@@ -48,11 +48,18 @@ says they should be, and rewrites anything that drifted. What gets compared is
 declared in **`adopt/facebook/field_contract.py`** — one dict per object type,
 each field with a sentence saying why we care about it.
 
-The subtle part is that Facebook does not echo everything back. Some fields it
-accepts on write and simply omits from the response. Comparing such a field is
-a trap: we send it, Facebook drops it, we see a difference, we rewrite — every
-run, forever. `field_contract.DROPPED` is the list of fields known to behave
-this way, and those are excluded from comparison.
+The subtle part is that Facebook does not echo everything back the way we sent
+it. Two things go wrong, and both cause an endless rewrite loop — we send a
+field, Facebook returns something that does not match, we rewrite, forever:
+
+- **`DROPPED`** — fields Facebook accepts on write and simply omits from the
+  response. Excluded from comparison.
+- **`NORMALIZE`** — fields Facebook returns in a different representation than
+  we send: `daily_budget` comes back as a string where we set an int,
+  `end_time` as a tz-offset ISO string where we set a naive datetime. Same
+  value, so `==` is False forever. Each entry canonicalises both sides first.
+  These are hand-written, since a normaliser encodes what "the same" means for
+  a field and no probe can infer that.
 
 An **undeclared** nested drop is still treated as a difference, deliberately.
 A real change that must be applied — converting a creative from `photo_data`
@@ -69,8 +76,10 @@ poetry run adopt-probe <study-id-or-name>            # read-only report
 poetry run adopt-probe <study-id-or-name> --update   # rewrite DROPPED
 ```
 
-The probe builds the creative a study's config asks for, fetches the live ad,
-and classifies every field path:
+The probe builds the creative and adset a study's config asks for, fetches the
+live ones, and classifies every field path. It reports ads and adsets
+separately, since they are compared in opposite argument orders — see
+`planning/field-contract.md`. Verdicts:
 
 | verdict | meaning |
 |---|---|

--- a/adopt/README.md
+++ b/adopt/README.md
@@ -41,6 +41,52 @@ misalign.
 `test_marketing.py` covers this with contiguous, interleaved, and unequal-sized
 arm orderings — ordering must never influence the result.
 
+## The Facebook field contract
+
+Every run, adopt compares the live ads and adsets against what the study config
+says they should be, and rewrites anything that drifted. What gets compared is
+declared in **`adopt/facebook/field_contract.py`** — one dict per object type,
+each field with a sentence saying why we care about it.
+
+The subtle part is that Facebook does not echo everything back. Some fields it
+accepts on write and simply omits from the response. Comparing such a field is
+a trap: we send it, Facebook drops it, we see a difference, we rewrite — every
+run, forever. `field_contract.DROPPED` is the list of fields known to behave
+this way, and those are excluded from comparison.
+
+An **undeclared** nested drop is still treated as a difference, deliberately.
+A real change that must be applied — converting a creative from `photo_data`
+to `link_data`, say — looks identical in the data to a field Facebook silently
+drops. Nothing distinguishes them, so the call belongs to a human. What the
+code does instead is warn loudly, naming the path and the command that
+resolves it. (A *whole* top-level field missing from Facebook's response is
+skipped rather than rewritten — see `planning/field-contract.md`.)
+
+### Checking the contract against Facebook
+
+```bash
+poetry run adopt-probe <study-id-or-name>            # read-only report
+poetry run adopt-probe <study-id-or-name> --update   # rewrite DROPPED
+```
+
+The probe builds the creative a study's config asks for, fetches the live ad,
+and classifies every field path:
+
+| verdict | meaning |
+|---|---|
+| `ok` | sent it, Facebook echoed it back unchanged |
+| `dropped` | sent it, Facebook did not return it — declare it or stop sending it |
+| `differs` | sent it, Facebook returned something else — a real change |
+| `stale` | declared `DROPPED`, but Facebook returns it now — undeclare it |
+
+It exits non-zero when the contract and Facebook disagree, so it can gate a
+deploy. `--update` rewrites the `DROPPED` block in place, stamped with today's
+date; review it as a normal git diff.
+
+It is read-only by default because it points at ads spending real money.
+
+Background on the incident that motivated this: `planning/field-contract.md`.
+
 ## Configuration
 
 Some documentation for configuring a vlab study:

--- a/adopt/adopt/facebook/field_contract.py
+++ b/adopt/adopt/facebook/field_contract.py
@@ -65,9 +65,29 @@ COMPARED_ADSET: Dict[str, str] = {
 #
 # BEGIN DROPPED (managed by adopt-probe)
 DROPPED: Dict[str, str] = {
+    "degrees_of_freedom_spec.creative_features_spec.image_animation": (
+        "Sent by adopt, absent from Facebook's response. Confirmed live 2026-08-01 "
+        "by adopt-probe."
+    ),
+    "degrees_of_freedom_spec.creative_features_spec.image_brightness_and_contrast": (
+        "Sent by adopt, absent from Facebook's response. Confirmed live 2026-08-01 "
+        "by adopt-probe."
+    ),
+    "degrees_of_freedom_spec.creative_features_spec.image_templates": (
+        "Sent by adopt, absent from Facebook's response. Confirmed live 2026-08-01 "
+        "by adopt-probe."
+    ),
     "degrees_of_freedom_spec.creative_features_spec.image_text_translation": (
         "We send enroll_status OPT_IN; Facebook returns ~82 creative_features_spec "
         "keys and this is never among them. Confirmed live 2026-07-30."
+    ),
+    "degrees_of_freedom_spec.creative_features_spec.image_touchups": (
+        "Sent by adopt, absent from Facebook's response. Confirmed live 2026-08-01 "
+        "by adopt-probe."
+    ),
+    "degrees_of_freedom_spec.creative_features_spec.text_optimizations": (
+        "Sent by adopt, absent from Facebook's response. Confirmed live 2026-08-01 "
+        "by adopt-probe."
     ),
 }
 # END DROPPED (managed by adopt-probe)

--- a/adopt/adopt/facebook/field_contract.py
+++ b/adopt/adopt/facebook/field_contract.py
@@ -15,7 +15,8 @@ Keep this file honest with `adopt-probe`, which compares these declarations
 against live ads and tells you what changed.
 """
 
-from typing import Dict
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict
 
 # Ad creative fields we compare. The ad's referral `ref` — which decides
 # which survey a respondent enters — lives in three of them, so drift here
@@ -91,6 +92,47 @@ DROPPED: Dict[str, str] = {
     ),
 }
 # END DROPPED (managed by adopt-probe)
+
+
+# Fields Facebook returns in a different representation than we send.
+#
+# Same meaning, different type — so a plain `==` is always False and the object
+# is rewritten every run even when nothing changed. Each entry canonicalises
+# both sides before they are compared.
+#
+# Unlike DROPPED, these are hand-written: a normaliser is a decision about what
+# "the same" means for a field, which is not something a probe can infer.
+NORMALIZE: Dict[str, Callable[[Any], Any]] = {
+    "daily_budget": lambda v: int(v),
+    "end_time": lambda v: _as_instant(v),
+}
+
+
+def _as_instant(v: Any) -> Any:
+    """Reduce a Facebook timestamp and ours to the same comparable moment.
+
+    create_adset sets a naive UTC datetime; Facebook returns an ISO string in
+    the ad account's timezone ('2026-08-03T02:00:00+0200'). Those are the same
+    instant and must compare equal. Python 3.10's fromisoformat cannot parse a
+    '+0200' offset without a colon, hence strptime.
+    """
+    if isinstance(v, str):
+        try:
+            v = datetime.strptime(v, "%Y-%m-%dT%H:%M:%S%z")
+        except ValueError:
+            return v
+
+    if isinstance(v, datetime):
+        if v.tzinfo is None:
+            v = v.replace(tzinfo=timezone.utc)
+        return v.astimezone(timezone.utc).timestamp()
+
+    return v
+
+
+def normalizer_for(path: str):
+    """The normaliser for `path`, or None. Paths may carry a leading dot."""
+    return NORMALIZE.get(path.lstrip("."))
 
 
 def is_dropped(path: str) -> bool:

--- a/adopt/adopt/facebook/field_contract.py
+++ b/adopt/adopt/facebook/field_contract.py
@@ -1,0 +1,82 @@
+"""What we compare against Facebook, and why.
+
+`reconciliation._eq` decides whether a live ad or adset still matches what the
+study config says it should be. Anything listed in COMPARED_AD / COMPARED_ADSET
+is part of that decision; anything else Facebook returns is ignored.
+
+Adding a field here is not free. If Facebook does not echo a field back exactly
+as we sent it, every run will see a difference and rewrite the object — forever.
+That is not hypothetical: `image_text_translation` did precisely this, costing
+~360 no-op ad writes a day against a single ad account until 2026-07-30, and
+contributing to `code 17 / Ad Account Has Too Many API Calls` throttling. See
+planning/field-contract.md.
+
+Keep this file honest with `adopt-probe`, which compares these declarations
+against live ads and tells you what changed.
+"""
+
+from typing import Dict
+
+# Ad creative fields we compare. The ad's referral `ref` — which decides
+# which survey a respondent enters — lives in three of them, so drift here
+# is not cosmetic.
+COMPARED_AD: Dict[str, str] = {
+    "object_story_spec": (
+        "Holds page_welcome_message, whose quick-reply payload carries the "
+        "referral ref. Wrong value recruits people into the wrong survey."
+    ),
+    "asset_feed_spec": (
+        "Ad copy variants, plus additional_data.page_welcome_message — the "
+        "same ref again for Advantage+ delivery."
+    ),
+    "url_tags": "The ref as a click parameter (ref=creative.<name>....).",
+    "degrees_of_freedom_spec": (
+        "Advantage+ creative opt-ins. Which enhancements Facebook may apply "
+        "to our creative changes what respondents actually see."
+    ),
+    "actor_id": "The Facebook page the ad posts as.",
+    "instagram_user_id": "The Instagram account the ad runs under.",
+    "image_crops": "Crop spec for the creative image.",
+    "contextual_multi_ads": "Opt-in for contextual multi-ads placement.",
+}
+
+# Adset fields we compare.
+COMPARED_ADSET: Dict[str, str] = {
+    "targeting": "Who the stratum recruits — the study design itself.",
+    "daily_budget": "Set every run by the optimizer; drift means overspend.",
+    "end_time": "Flight end, from the study's recruitment window.",
+    "status": "ACTIVE vs PAUSED — a paused stratum recruits nobody.",
+    "optimization_goal": "What Facebook optimizes delivery for.",
+    "name": "The stratum id. Adsets are matched to strata by this.",
+}
+
+
+# Fields Facebook accepts on write but never echoes back on read.
+#
+# These must not count as differences. We send the field, Facebook stores it
+# (or silently ignores it) but omits it from the response, we see it missing,
+# we write again — every run, forever.
+#
+# Paths are dotted, relative to the compared object (the creative for ads, the
+# adset for adsets), matching the paths `_eq` walks.
+#
+# Managed by `adopt-probe --update`. Edit by hand if you like; the tool
+# rewrites everything between the markers below.
+#
+# BEGIN DROPPED (managed by adopt-probe)
+DROPPED: Dict[str, str] = {
+    "degrees_of_freedom_spec.creative_features_spec.image_text_translation": (
+        "We send enroll_status OPT_IN; Facebook returns ~82 creative_features_spec "
+        "keys and this is never among them. Confirmed live 2026-07-30."
+    ),
+}
+# END DROPPED (managed by adopt-probe)
+
+
+def is_dropped(path: str) -> bool:
+    """True if Facebook is known not to echo `path` back.
+
+    `_eq` builds paths with a leading dot (".degrees_of_freedom_spec..."),
+    so normalise before looking up.
+    """
+    return path.lstrip(".") in DROPPED

--- a/adopt/adopt/facebook/probe.py
+++ b/adopt/adopt/facebook/probe.py
@@ -1,0 +1,352 @@
+"""Check the field contract against live Facebook ads.
+
+    adopt-probe <study-id-or-name>            # read-only report
+    adopt-probe <study-id-or-name> --update   # also rewrite DROPPED
+
+For every field in field_contract.COMPARED_AD, this builds the creative the
+study config says an ad should have — the same way `adset_instructions` does —
+fetches the live ad, and classifies each leaf path:
+
+    ok       we sent it, Facebook echoed it back unchanged
+    dropped  we sent it, Facebook did not return it at all
+    differs  we sent it, Facebook returned something else
+    stale    declared DROPPED, but Facebook does return it now
+
+`dropped` paths that are not declared are what cause endless rewrites, so they
+are the point of this tool. `--update` writes them into field_contract.DROPPED
+with today's date; review the git diff as you would any other change.
+
+Read-only by default: it points at ads that are spending real money.
+"""
+
+import argparse
+import json
+import logging
+import re
+import sys
+from collections import defaultdict
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from environs import Env
+
+from ..malaria import hydrate_strata, load_basics
+from ..marketing import create_creative, pair_creatives_with_destinations
+from ..study_conf import StudyConf
+from . import field_contract
+from .state import FacebookState
+
+logger = logging.getLogger(__name__)
+
+OK = "ok"
+DROPPED = "dropped"
+DIFFERS = "differs"
+
+CONTRACT_PATH = Path(field_contract.__file__)
+BEGIN = "# BEGIN DROPPED (managed by adopt-probe)"
+END = "# END DROPPED (managed by adopt-probe)"
+
+
+def _unwrap(x: Any) -> Any:
+    """Facebook SDK objects and plain dicts both show up; normalise to dicts."""
+    try:
+        return x.export_all_data()
+    except AttributeError:
+        return x
+
+
+def classify(
+    desired: Any, source: Any, fields: List[str]
+) -> List[Tuple[str, str, Any, Any]]:
+    """Walk `fields` of desired vs source, returning (path, verdict, want, got).
+
+    Mirrors how reconciliation._eq traverses, but reports every leaf instead of
+    short-circuiting on the first difference — the whole point is to see all of
+    them at once.
+    """
+    findings: List[Tuple[str, str, Any, Any]] = []
+
+    d, s = _unwrap(desired), _unwrap(source)
+    if not isinstance(d, dict) or not isinstance(s, dict):
+        return findings
+
+    for f in fields:
+        if f not in d:
+            continue
+        if f not in s:
+            findings.append((f".{f}", DROPPED, d[f], None))
+            continue
+        findings.extend(_walk(d[f], s[f], f".{f}"))
+
+    return findings
+
+
+def _walk(want: Any, got: Any, path: str) -> List[Tuple[str, str, Any, Any]]:
+    want, got = _unwrap(want), _unwrap(got)
+
+    if isinstance(want, dict) and isinstance(got, dict):
+        out: List[Tuple[str, str, Any, Any]] = []
+        for k, v in want.items():
+            if k not in got:
+                out.append((f"{path}.{k}", DROPPED, v, None))
+                continue
+            out.extend(_walk(v, got[k], f"{path}.{k}"))
+        return out
+
+    # Lists and scalars are compared whole. Facebook reorders lists, so sort
+    # them the same way _eq does before comparing.
+    if isinstance(want, list) and isinstance(got, list):
+        key = lambda x: json.dumps(x, sort_keys=True, default=str)  # noqa: E731
+        same = len(want) == len(got) and sorted(want, key=key) == sorted(got, key=key)
+        return [(path, OK if same else DIFFERS, want, got)]
+
+    return [(path, OK if want == got else DIFFERS, want, got)]
+
+
+def probe_study(study: StudyConf, state: FacebookState) -> List[Tuple[str, str, Any, Any]]:
+    """Classify every compared field across every live ad in the study."""
+    strata = hydrate_strata(state, study.strata, study.creatives)
+    by_id = {s.id: s for s in strata}
+    fields = list(field_contract.COMPARED_AD)
+
+    findings: List[Tuple[str, str, Any, Any]] = []
+
+    for campaign_name in study.campaign_names:
+        try:
+            cs = state.campaign_state(campaign_name)
+            live = cs.campaign_state
+        except Exception as e:
+            logger.warning(f"skipping campaign {campaign_name}: {e}")
+            continue
+
+        for adset, ads in live:
+            stratum = by_id.get(_unwrap(adset).get("name"))
+            if stratum is None:
+                continue
+
+            pairs = pair_creatives_with_destinations(study, stratum, campaign_name)
+            desired = {
+                c.name: create_creative(study, stratum, c, d) for c, d in pairs
+            }
+
+            for ad in ads:
+                a = _unwrap(ad)
+                want = desired.get(a.get("name"))
+                if want is None or "creative" not in a:
+                    continue
+                findings.extend(classify(want, a["creative"], fields))
+
+    return findings
+
+
+def summarise(findings) -> Dict[str, Dict[str, Any]]:
+    """Collapse per-ad findings into one row per path."""
+    counts: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    examples: Dict[str, Tuple[Any, Any]] = {}
+
+    for path, verdict, want, got in findings:
+        counts[path][verdict] += 1
+        if verdict != OK and path not in examples:
+            examples[path] = (want, got)
+
+    rows = {}
+    for path, c in counts.items():
+        # A path is only "clean" if it was clean on every ad.
+        verdict = OK
+        if c.get(DIFFERS):
+            verdict = DIFFERS
+        elif c.get(DROPPED):
+            verdict = DROPPED
+
+        declared = field_contract.is_dropped(path)
+        rows[path] = {
+            "verdict": verdict,
+            "declared_dropped": declared,
+            "ads": sum(c.values()),
+            "hits": c.get(verdict, 0),
+            "example": examples.get(path),
+        }
+
+    # Declared drops that Facebook now echoes back are stale declarations.
+    for path, row in rows.items():
+        if row["declared_dropped"] and row["verdict"] != DROPPED:
+            row["verdict"] = "stale"
+
+    return rows
+
+
+def render(rows: Dict[str, Dict[str, Any]]) -> str:
+    undeclared = sorted(
+        p for p, r in rows.items() if r["verdict"] == DROPPED and not r["declared_dropped"]
+    )
+    declared = sorted(
+        p for p, r in rows.items() if r["verdict"] == DROPPED and r["declared_dropped"]
+    )
+    differs = sorted(p for p, r in rows.items() if r["verdict"] == DIFFERS)
+    stale = sorted(p for p, r in rows.items() if r["verdict"] == "stale")
+    ok = sorted(p for p, r in rows.items() if r["verdict"] == OK)
+
+    out = []
+    out.append(f"compared {len(rows)} field paths across live ads\n")
+
+    if undeclared:
+        out.append("UNDECLARED DROPS — these cause a rewrite every run:")
+        for p in undeclared:
+            out.append(f"  {p}  ({rows[p]['hits']}/{rows[p]['ads']} ads)")
+        out.append("  declare them with --update, or stop sending them\n")
+
+    if differs:
+        out.append("VALUE DIFFERS — a real change, will be rewritten once:")
+        for p in differs:
+            want, got = rows[p]["example"] or (None, None)
+            out.append(f"  {p}\n    want={want!r}\n    got ={got!r}")
+        out.append("")
+
+    if stale:
+        out.append("STALE DECLARATIONS — Facebook returns these now, undeclare them:")
+        for p in stale:
+            out.append(f"  {p}")
+        out.append("")
+
+    if declared:
+        out.append(f"declared drops, still dropped: {len(declared)}")
+        for p in declared:
+            out.append(f"  {p}")
+        out.append("")
+
+    out.append(f"clean: {len(ok)} paths")
+
+    if not undeclared and not differs and not stale:
+        out.append("\ncontract matches live Facebook behaviour.")
+
+    return "\n".join(out)
+
+
+def render_dropped_block(paths: Dict[str, str]) -> str:
+    """Regenerate the DROPPED literal between the markers."""
+    lines = [BEGIN, "DROPPED: Dict[str, str] = {"]
+    for path in sorted(paths):
+        why = paths[path]
+        lines.append(f'    "{path}": (')
+        for chunk in _wrap(why, 74):
+            lines.append(f'        "{chunk}"')
+        lines.append("    ),")
+    lines.append("}")
+    lines.append(END)
+    return "\n".join(lines)
+
+
+def _wrap(text: str, width: int) -> List[str]:
+    """Wrap `text` into string-literal chunks, keeping a trailing space."""
+    words, lines, cur = text.split(), [], ""
+    for w in words:
+        if cur and len(cur) + len(w) + 1 > width:
+            lines.append(cur + " ")
+            cur = w
+        else:
+            cur = f"{cur} {w}".strip()
+    if cur:
+        lines.append(cur)
+    return lines or [""]
+
+
+def update_contract(rows: Dict[str, Dict[str, Any]], today: str) -> Optional[str]:
+    """Rewrite DROPPED to match what the probe just saw. Returns new file text."""
+    keep = {
+        p: why
+        for p, why in field_contract.DROPPED.items()
+        # Drop declarations Facebook has started honouring again.
+        if rows.get(f".{p}", {}).get("verdict") != "stale"
+    }
+
+    for path, row in rows.items():
+        if row["verdict"] == DROPPED and not row["declared_dropped"]:
+            keep[path.lstrip(".")] = (
+                f"Sent by adopt, absent from Facebook's response. "
+                f"Confirmed live {today} by adopt-probe."
+            )
+
+    if keep == field_contract.DROPPED:
+        return None
+
+    text = CONTRACT_PATH.read_text()
+    block = render_dropped_block(keep)
+    new = re.sub(
+        re.escape(BEGIN) + r".*?" + re.escape(END), block, text, flags=re.DOTALL
+    )
+    return new if new != text else None
+
+
+def resolve_study_id(db_conf, ident: str) -> str:
+    """Accept either a study id or a study name."""
+    from ..db import query  # local import: keeps module import cheap for tests
+
+    rows = query(db_conf, "select id from studies where id::text = %s", [ident])
+    if rows:
+        return ident
+
+    rows = query(db_conf, "select id from studies where name = %s", [ident])
+    if not rows:
+        raise SystemExit(f"no study with id or name {ident!r}")
+    if len(rows) > 1:
+        raise SystemExit(f"{ident!r} matches {len(rows)} studies — pass the id")
+    return str(rows[0][0])
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="adopt-probe", description="Check the field contract against live ads."
+    )
+    parser.add_argument("study", help="study id or name")
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="rewrite field_contract.DROPPED to match what was found",
+    )
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
+
+    env = Env()
+    db_conf = env("PG_URL")
+
+    study_id = resolve_study_id(db_conf, args.study)
+    study, state = load_basics(study_id, db_conf, env)
+
+    findings = probe_study(study, state)
+    if not findings:
+        print("no live ads matched this study's config — nothing to compare")
+        return 0
+
+    rows = summarise(findings)
+
+    if args.json:
+        print(
+            json.dumps(
+                {p: {k: v for k, v in r.items() if k != "example"} for p, r in rows.items()},
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(render(rows))
+
+    if args.update:
+        new = update_contract(rows, date.today().isoformat())
+        if new is None:
+            print("\nfield_contract.DROPPED already matches — nothing written")
+        else:
+            CONTRACT_PATH.write_text(new)
+            print(f"\nwrote {CONTRACT_PATH} — review the diff")
+
+    dirty = any(
+        r["verdict"] == DROPPED and not r["declared_dropped"] or r["verdict"] == "stale"
+        for r in rows.values()
+    )
+    return 1 if dirty and not args.update else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/adopt/adopt/facebook/probe.py
+++ b/adopt/adopt/facebook/probe.py
@@ -104,13 +104,20 @@ def _walk(want: Any, got: Any, path: str) -> List[Tuple[str, str, Any, Any]]:
     return [(path, OK if want == got else DIFFERS, want, got)]
 
 
-def probe_study(study: StudyConf, state: FacebookState) -> List[Tuple[str, str, Any, Any]]:
-    """Classify every compared field across every live ad in the study."""
+def probe_study(
+    study: StudyConf, state: FacebookState
+) -> Tuple[List[Tuple[str, str, Any, Any]], int]:
+    """Classify every compared field across every live ad in the study.
+
+    Returns the findings and how many ads were actually compared — a report
+    over 3 ads and one over 300 deserve different amounts of trust.
+    """
     strata = hydrate_strata(state, study.strata, study.creatives)
     by_id = {s.id: s for s in strata}
     fields = list(field_contract.COMPARED_AD)
 
     findings: List[Tuple[str, str, Any, Any]] = []
+    ads_compared = 0
 
     for campaign_name in study.campaign_names:
         try:
@@ -136,8 +143,9 @@ def probe_study(study: StudyConf, state: FacebookState) -> List[Tuple[str, str, 
                 if want is None or "creative" not in a:
                     continue
                 findings.extend(classify(want, a["creative"], fields))
+                ads_compared += 1
 
-    return findings
+    return findings, ads_compared
 
 
 def summarise(findings) -> Dict[str, Dict[str, Any]]:
@@ -176,7 +184,7 @@ def summarise(findings) -> Dict[str, Dict[str, Any]]:
     return rows
 
 
-def render(rows: Dict[str, Dict[str, Any]]) -> str:
+def render(rows: Dict[str, Dict[str, Any]], ads_compared: int = 0) -> str:
     undeclared = sorted(
         p for p, r in rows.items() if r["verdict"] == DROPPED and not r["declared_dropped"]
     )
@@ -188,7 +196,7 @@ def render(rows: Dict[str, Dict[str, Any]]) -> str:
     ok = sorted(p for p, r in rows.items() if r["verdict"] == OK)
 
     out = []
-    out.append(f"compared {len(rows)} field paths across live ads\n")
+    out.append(f"compared {len(rows)} field paths across {ads_compared} live ads\n")
 
     if undeclared:
         out.append("UNDECLARED DROPS — these cause a rewrite every run:")
@@ -282,11 +290,13 @@ def resolve_study_id(db_conf, ident: str) -> str:
     """Accept either a study id or a study name."""
     from ..db import query  # local import: keeps module import cheap for tests
 
-    rows = query(db_conf, "select id from studies where id::text = %s", [ident])
+    # db.query is a generator — materialise it, or every check below is
+    # truthy and the name gets passed through as if it were an id.
+    rows = list(query(db_conf, "select id from studies where id::text = %s", [ident]))
     if rows:
         return ident
 
-    rows = query(db_conf, "select id from studies where name = %s", [ident])
+    rows = list(query(db_conf, "select id from studies where name = %s", [ident]))
     if not rows:
         raise SystemExit(f"no study with id or name {ident!r}")
     if len(rows) > 1:
@@ -315,7 +325,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     study_id = resolve_study_id(db_conf, args.study)
     study, state = load_basics(study_id, db_conf, env)
 
-    findings = probe_study(study, state)
+    findings, ads_compared = probe_study(study, state)
     if not findings:
         print("no live ads matched this study's config — nothing to compare")
         return 0
@@ -331,7 +341,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             )
         )
     else:
-        print(render(rows))
+        print(render(rows, ads_compared))
 
     if args.update:
         new = update_contract(rows, date.today().isoformat())

--- a/adopt/adopt/facebook/probe.py
+++ b/adopt/adopt/facebook/probe.py
@@ -281,13 +281,16 @@ def render(
     stale = sorted(p for p, r in rows.items() if r["verdict"] == "stale")
     ok = sorted(p for p, r in rows.items() if r["verdict"] == OK)
 
+    # "live adsets" -> "adsets", so adset findings are not counted in "ads".
+    unit = what.split()[-1]
+
     out = []
     out.append(f"compared {len(rows)} field paths across {ads_compared} {what}\n")
 
     if undeclared:
         out.append(missing_label)
         for p in undeclared:
-            out.append(f"  {p}  ({rows[p]['hits']}/{rows[p]['ads']} ads)")
+            out.append(f"  {p}  ({rows[p]['hits']}/{rows[p]['ads']} {unit})")
         out.append("  declare them with --update, or stop sending them\n")
 
     if differs:

--- a/adopt/adopt/facebook/probe.py
+++ b/adopt/adopt/facebook/probe.py
@@ -32,9 +32,16 @@ from typing import Any, Dict, List, Optional, Tuple
 from environs import Env
 
 from ..malaria import hydrate_strata, load_basics
-from ..marketing import create_creative, pair_creatives_with_destinations
-from ..study_conf import StudyConf
+from ..marketing import (
+    ADSET_HOURS,
+    AdsetConf,
+    create_adset,
+    create_creative,
+    pair_creatives_with_destinations,
+)
+from ..study_conf import AppDestination, StudyConf
 from . import field_contract
+from .reconciliation import _eq
 from .state import FacebookState
 
 logger = logging.getLogger(__name__)
@@ -85,6 +92,15 @@ def classify(
 def _walk(want: Any, got: Any, path: str) -> List[Tuple[str, str, Any, Any]]:
     want, got = _unwrap(want), _unwrap(got)
 
+    # Mirror _eq: canonicalise representations before comparing, or the probe
+    # reports differences the reconciler does not act on.
+    normalize = field_contract.normalizer_for(path)
+    if normalize is not None:
+        try:
+            want, got = normalize(want), normalize(got)
+        except (TypeError, ValueError):
+            pass
+
     if isinstance(want, dict) and isinstance(got, dict):
         out: List[Tuple[str, str, Any, Any]] = []
         for k, v in want.items():
@@ -94,25 +110,27 @@ def _walk(want: Any, got: Any, path: str) -> List[Tuple[str, str, Any, Any]]:
             out.extend(_walk(v, got[k], f"{path}.{k}"))
         return out
 
-    # Lists and scalars are compared whole. Facebook reorders lists, so sort
-    # them the same way _eq does before comparing.
-    if isinstance(want, list) and isinstance(got, list):
-        key = lambda x: json.dumps(x, sort_keys=True, default=str)  # noqa: E731
-        same = len(want) == len(got) and sorted(want, key=key) == sorted(got, key=key)
-        return [(path, OK if same else DIFFERS, want, got)]
-
-    return [(path, OK if want == got else DIFFERS, want, got)]
+    # Lists and scalars are compared by _eq itself rather than reimplemented
+    # here. Its list handling is subtle — sorted for order-independence, then
+    # element dicts compared on shared keys only, because Facebook reorders
+    # audience refs and strips `name` from some entries. A second
+    # implementation would drift from it and report differences the reconciler
+    # never acts on.
+    return [(path, OK if _eq(want, got, _path=path) else DIFFERS, want, got)]
 
 
 def probe_study(
-    study: StudyConf, state: FacebookState
+    study: StudyConf, state: FacebookState, strata
 ) -> Tuple[List[Tuple[str, str, Any, Any]], int]:
     """Classify every compared field across every live ad in the study.
 
     Returns the findings and how many ads were actually compared — a report
     over 3 ads and one over 300 deserve different amounts of trust.
+
+    `strata` is passed in rather than hydrated here: hydrate_strata appends to
+    the stratum's excluded_custom_audiences in place, so calling it twice in
+    one process duplicates entries and invents differences that do not exist.
     """
-    strata = hydrate_strata(state, study.strata, study.creatives)
     by_id = {s.id: s for s in strata}
     fields = list(field_contract.COMPARED_AD)
 
@@ -146,6 +164,69 @@ def probe_study(
                 ads_compared += 1
 
     return findings, ads_compared
+
+
+def probe_adsets(
+    study: StudyConf, state: FacebookState, strata
+) -> Tuple[List[Tuple[str, str, Any, Any]], int]:
+    """Classify every compared field across every live adset in the study.
+
+    Compared in the same argument order `update_adset` uses — `_eq(live,
+    desired)` — so a clean report means the reconciler really will no-op.
+    Note that this is the reverse of the ad path, which compares
+    `_eq(desired, live)`.
+
+    The live adset's budget and status are fed back in as the desired ones.
+    The optimizer moves the budget every run by design; that is an intended
+    change, not drift, and leaving it in would bury the representation
+    problems this is looking for.
+    """
+    by_id = {s.id: s for s in strata}
+    fields = list(field_contract.COMPARED_ADSET)
+
+    findings: List[Tuple[str, str, Any, Any]] = []
+    adsets_compared = 0
+
+    for campaign_name in study.campaign_names:
+        try:
+            cs = state.campaign_state(campaign_name)
+            live_adsets = cs.campaign_state
+        except Exception as e:
+            logger.warning(f"skipping campaign {campaign_name}: {e}")
+            continue
+
+        for live, _ads in live_adsets:
+            data = _unwrap(live)
+            stratum = by_id.get(data.get("name"))
+            if stratum is None:
+                continue
+
+            pairs = pair_creatives_with_destinations(study, stratum, campaign_name)
+            promoted_object = None
+            if pairs and isinstance(pairs[0][1], AppDestination):
+                d = pairs[0][1]
+                promoted_object = {
+                    "application_id": d.facebook_app_id,
+                    "object_store_url": d.app_install_link,
+                }
+
+            desired = create_adset(
+                AdsetConf(
+                    cs.campaign,
+                    stratum,
+                    int(data.get("daily_budget") or 0),
+                    data.get("status", "ACTIVE"),
+                    ADSET_HOURS,
+                    study.recruitment.optimization_goal,
+                    study.recruitment.destination_type,
+                    promoted_object,
+                )
+            )
+
+            findings.extend(classify(live, desired, fields))
+            adsets_compared += 1
+
+    return findings, adsets_compared
 
 
 def summarise(findings) -> Dict[str, Dict[str, Any]]:
@@ -184,7 +265,12 @@ def summarise(findings) -> Dict[str, Dict[str, Any]]:
     return rows
 
 
-def render(rows: Dict[str, Dict[str, Any]], ads_compared: int = 0) -> str:
+def render(
+    rows: Dict[str, Dict[str, Any]],
+    ads_compared: int = 0,
+    what: str = "live ads",
+    missing_label: str = "UNDECLARED DROPS — these cause a rewrite every run:",
+) -> str:
     undeclared = sorted(
         p for p, r in rows.items() if r["verdict"] == DROPPED and not r["declared_dropped"]
     )
@@ -196,10 +282,10 @@ def render(rows: Dict[str, Dict[str, Any]], ads_compared: int = 0) -> str:
     ok = sorted(p for p, r in rows.items() if r["verdict"] == OK)
 
     out = []
-    out.append(f"compared {len(rows)} field paths across {ads_compared} live ads\n")
+    out.append(f"compared {len(rows)} field paths across {ads_compared} {what}\n")
 
     if undeclared:
-        out.append("UNDECLARED DROPS — these cause a rewrite every run:")
+        out.append(missing_label)
         for p in undeclared:
             out.append(f"  {p}  ({rows[p]['hits']}/{rows[p]['ads']} ads)")
         out.append("  declare them with --update, or stop sending them\n")
@@ -325,37 +411,69 @@ def main(argv: Optional[List[str]] = None) -> int:
     study_id = resolve_study_id(db_conf, args.study)
     study, state = load_basics(study_id, db_conf, env)
 
-    findings, ads_compared = probe_study(study, state)
-    if not findings:
-        print("no live ads matched this study's config — nothing to compare")
+    # Hydrated once and shared: hydrate_strata mutates the strata it is given.
+    strata = hydrate_strata(state, study.strata, study.creatives)
+
+    ad_findings, ads_compared = probe_study(study, state, strata)
+    adset_findings, adsets_compared = probe_adsets(study, state, strata)
+
+    if not ad_findings and not adset_findings:
+        print("no live ads or adsets matched this study's config — nothing to compare")
         return 0
 
-    rows = summarise(findings)
+    ad_rows = summarise(ad_findings)
+    adset_rows = summarise(adset_findings)
 
     if args.json:
         print(
             json.dumps(
-                {p: {k: v for k, v in r.items() if k != "example"} for p, r in rows.items()},
+                {
+                    "ads": _jsonable(ad_rows),
+                    "adsets": _jsonable(adset_rows),
+                },
                 indent=2,
                 sort_keys=True,
             )
         )
     else:
-        print(render(rows, ads_compared))
+        print("ADS")
+        print(render(ad_rows, ads_compared))
+        print("\nADSETS")
+        print(
+            render(
+                adset_rows,
+                adsets_compared,
+                what="live adsets",
+                # Adsets are compared _eq(live, desired), so a key missing here
+                # is one Facebook returns and we never send — the mirror image
+                # of the ad case.
+                missing_label="RETURNED BY FACEBOOK, NEVER SENT BY US:",
+            )
+        )
 
     if args.update:
-        new = update_contract(rows, date.today().isoformat())
+        # Only the ad direction feeds DROPPED: there "missing" means Facebook
+        # did not echo what we sent, which is what DROPPED declares. The adset
+        # direction means the opposite and must be read by a human.
+        new = update_contract(ad_rows, date.today().isoformat())
         if new is None:
             print("\nfield_contract.DROPPED already matches — nothing written")
         else:
             CONTRACT_PATH.write_text(new)
             print(f"\nwrote {CONTRACT_PATH} — review the diff")
 
-    dirty = any(
-        r["verdict"] == DROPPED and not r["declared_dropped"] or r["verdict"] == "stale"
-        for r in rows.values()
-    )
+    def _dirty(rows):
+        return any(
+            r["verdict"] == DROPPED and not r["declared_dropped"] or r["verdict"] == "stale"
+            for r in rows.values()
+        )
+
+    dirty = _dirty(ad_rows) or _dirty(adset_rows)
     return 1 if dirty and not args.update else 0
+
+
+def _jsonable(rows: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    return {p: {k: v for k, v in r.items() if k != "example"} for p, r in rows.items()}
 
 
 if __name__ == "__main__":

--- a/adopt/adopt/facebook/probe.py
+++ b/adopt/adopt/facebook/probe.py
@@ -82,7 +82,7 @@ def classify(
         if f not in d:
             continue
         if f not in s:
-            findings.append((f".{f}", DROPPED, d[f], None))
+            findings.append((f".{f}", OK if not d[f] else DROPPED, d[f], None))
             continue
         findings.extend(_walk(d[f], s[f], f".{f}"))
 
@@ -105,7 +105,9 @@ def _walk(want: Any, got: Any, path: str) -> List[Tuple[str, str, Any, Any]]:
         out: List[Tuple[str, str, Any, Any]] = []
         for k, v in want.items():
             if k not in got:
-                out.append((f"{path}.{k}", DROPPED, v, None))
+                # Mirror _eq: an empty value we asked for and Facebook elided
+                # is agreement, not a drop.
+                out.append((f"{path}.{k}", OK if not v else DROPPED, v, None))
                 continue
             out.extend(_walk(v, got[k], f"{path}.{k}"))
         return out
@@ -171,10 +173,8 @@ def probe_adsets(
 ) -> Tuple[List[Tuple[str, str, Any, Any]], int]:
     """Classify every compared field across every live adset in the study.
 
-    Compared in the same argument order `update_adset` uses — `_eq(live,
-    desired)` — so a clean report means the reconciler really will no-op.
-    Note that this is the reverse of the ad path, which compares
-    `_eq(desired, live)`.
+    Compared desired-first, the same order `update_adset` and `update_ad` both
+    use, so a clean report means the reconciler really will no-op.
 
     The live adset's budget and status are fed back in as the desired ones.
     The optimizer moves the budget every run by design; that is an intended
@@ -223,7 +223,7 @@ def probe_adsets(
                 )
             )
 
-            findings.extend(classify(live, desired, fields))
+            findings.extend(classify(desired, live, fields))
             adsets_compared += 1
 
     return findings, adsets_compared
@@ -439,23 +439,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         print("ADS")
         print(render(ad_rows, ads_compared))
         print("\nADSETS")
-        print(
-            render(
-                adset_rows,
-                adsets_compared,
-                what="live adsets",
-                # Adsets are compared _eq(live, desired), so a key missing here
-                # is one Facebook returns and we never send — the mirror image
-                # of the ad case.
-                missing_label="RETURNED BY FACEBOOK, NEVER SENT BY US:",
-            )
-        )
+        print(render(adset_rows, adsets_compared, what="live adsets"))
 
     if args.update:
-        # Only the ad direction feeds DROPPED: there "missing" means Facebook
-        # did not echo what we sent, which is what DROPPED declares. The adset
-        # direction means the opposite and must be read by a human.
-        new = update_contract(ad_rows, date.today().isoformat())
+        # Both directions are now desired-first, so "missing" means the same
+        # thing on each: Facebook did not echo back what we sent.
+        new = update_contract({**ad_rows, **adset_rows}, date.today().isoformat())
         if new is None:
             print("\nfield_contract.DROPPED already matches — nothing written")
         else:

--- a/adopt/adopt/facebook/reconciliation.py
+++ b/adopt/adopt/facebook/reconciliation.py
@@ -137,6 +137,18 @@ def _eq(a, b, fields=None, _path="", _subset=None) -> bool:
         if _subset == "a":
             for k, v in a.items():
                 if k not in b:
+                    # Asking for nothing and being shown nothing is agreement.
+                    # Facebook elides empty values rather than echoing them:
+                    # targeting.custom_audiences is always set (to [] when the
+                    # study has no audiences) and never comes back. Requesting
+                    # something non-empty and not seeing it is still a
+                    # difference, so adding an audience is not swallowed here.
+                    if not v:
+                        logger.debug(
+                            f"_eq: {_path}.{k} is empty and absent from source "
+                            "— treated as equal"
+                        )
+                        continue
                     if _declared_drop(f"{_path}.{k}"):
                         continue
                     return False
@@ -189,7 +201,13 @@ def update_adset(source: AdSet, adset: AdSet) -> List[Instruction]:
     # Declared, with rationale, in field_contract.COMPARED_ADSET.
     fields = list(field_contract.COMPARED_ADSET)
 
-    if _eq(source, adset, fields):
+    # (desired, live), the same order as update_ad. _eq treats its first
+    # argument as the authority — everything in it must match the second, and
+    # extras in the second are ignored. Facebook adds server-side defaults we
+    # never set, so the desired object has to come first. This used to be
+    # reversed here, which asked "is everything Facebook returned present in
+    # what we want?" — a different question, and the wrong one.
+    if _eq(adset, source, fields):
         logger.debug(
             f"update_adset: no-op for adset '{_safe_get(adset, 'name')}' "
             f"(id={_safe_get(source, 'id')})"

--- a/adopt/adopt/facebook/reconciliation.py
+++ b/adopt/adopt/facebook/reconciliation.py
@@ -2,10 +2,10 @@ import json
 import logging
 from typing import Dict, List, Sequence, Tuple, TypeVar
 
-from facebook_business.adobjects.adcreative import AdCreative
 from facebook_business.adobjects.ad import Ad
 from facebook_business.adobjects.adset import AdSet
 
+from . import field_contract
 from .update import Instruction
 
 logger = logging.getLogger(__name__)
@@ -17,6 +17,30 @@ def _safe_get(obj, key, default="unknown"):
         return obj[key]
     except (KeyError, TypeError):
         return default
+
+
+def _declared_drop(path: str) -> bool:
+    """True if field_contract says Facebook never echoes `path` back.
+
+    Anything else gets a warning, because an undeclared drop is what an
+    endless rewrite loop looks like on its first run: we send a field,
+    Facebook omits it from the response, we see a difference, we write again.
+    That loop ran ~360 no-op ad writes a day against one ad account until
+    2026-07-30 and helped trigger `code 17` throttling.
+
+    See planning/field-contract.md for why tolerance has to be declared per
+    field rather than inferred.
+    """
+    if field_contract.is_dropped(path):
+        logger.debug(f"_eq: declared drop at {path} — not compared")
+        return True
+
+    logger.warning(
+        f"_eq: undeclared drop at {path} — we set this field but Facebook did "
+        "not return it. Check with `adopt-probe <study>` and declare it in "
+        "field_contract.DROPPED (or stop sending it)."
+    )
+    return False
 
 
 def _sort_key(x):
@@ -73,10 +97,12 @@ def _eq(a, b, fields=None, _path="", _subset=None) -> bool:
                 if k not in fields:
                     continue
                 if k not in b:
-                    logger.debug(
-                        f"_eq: field '{k}' present in desired but missing from "
-                        f"source (path: {_path}.{k}) — skipping"
-                    )
+                    # Top level stays lenient, as it always has: a whole field
+                    # absent from Facebook's response is not something we can
+                    # act on, and treating it as a difference would rewrite
+                    # the object every run. Still worth a warning if it is not
+                    # a drop we already know about.
+                    _declared_drop(f"{_path}.{k}")
                     continue
                 if not _eq(v, b[k], _path=f"{_path}.{k}", _subset="a"):
                     logger.info(
@@ -89,14 +115,16 @@ def _eq(a, b, fields=None, _path="", _subset=None) -> bool:
         # Subset mode (nested recursion from a field-list call):
         # Compare only keys present in the desired object (a).  Extra keys
         # in the source (b) — server-generated defaults — are ignored.
-        # A key in desired that is missing from source IS a difference.
+        # A key in desired that is missing from source IS a difference, unless
+        # it is declared in field_contract.DROPPED.  It has to work this way:
+        # a real change (photo_data -> link_data) is indistinguishable in the
+        # data from a field Facebook silently drops, so only a declaration can
+        # tell them apart.  See _declared_drop.
         if _subset == "a":
             for k, v in a.items():
                 if k not in b:
-                    logger.info(
-                        f"_eq: key '{k}' in desired but missing from source "
-                        f"(path: {_path}.{k})"
-                    )
+                    if _declared_drop(f"{_path}.{k}"):
+                        continue
                     return False
                 if not _eq(v, b[k], _path=f"{_path}.{k}", _subset="a"):
                     logger.info(
@@ -144,14 +172,8 @@ def _eq(a, b, fields=None, _path="", _subset=None) -> bool:
 
 
 def update_adset(source: AdSet, adset: AdSet) -> List[Instruction]:
-    fields = [
-        AdSet.Field.end_time,
-        AdSet.Field.targeting,
-        AdSet.Field.status,
-        AdSet.Field.daily_budget,
-        AdSet.Field.optimization_goal,
-        AdSet.Field.name,
-    ]
+    # Declared, with rationale, in field_contract.COMPARED_ADSET.
+    fields = list(field_contract.COMPARED_ADSET)
 
     if _eq(source, adset, fields):
         logger.debug(
@@ -171,16 +193,8 @@ def update_adset(source: AdSet, adset: AdSet) -> List[Instruction]:
 
 def update_ad(source: Ad, ad: Ad) -> List[Instruction]:
 
-    fields = [
-        AdCreative.Field.actor_id,
-        AdCreative.Field.image_crops,
-        AdCreative.Field.asset_feed_spec,
-        AdCreative.Field.degrees_of_freedom_spec,
-        AdCreative.Field.instagram_user_id,
-        AdCreative.Field.object_story_spec,
-        AdCreative.Field.contextual_multi_ads,
-        AdCreative.Field.url_tags,
-    ]
+    # Declared, with rationale, in field_contract.COMPARED_AD.
+    fields = list(field_contract.COMPARED_AD)
 
     if not _eq(ad["creative"], source["creative"], fields):
         logger.warning(

--- a/adopt/adopt/facebook/reconciliation.py
+++ b/adopt/adopt/facebook/reconciliation.py
@@ -54,6 +54,20 @@ def _eq(a, b, fields=None, _path="", _subset=None) -> bool:
     except AttributeError:
         pass
 
+    # Facebook returns some fields in a different representation than we send
+    # (daily_budget as a string, end_time as a tz-offset ISO string). Without
+    # this, those compare unequal on every run and the object is rewritten
+    # forever even when nothing changed. See field_contract.NORMALIZE.
+    normalize = field_contract.normalizer_for(_path)
+    if normalize is not None:
+        try:
+            a, b = normalize(a), normalize(b)
+        except (TypeError, ValueError):
+            logger.warning(
+                f"_eq: normaliser for {_path} could not handle "
+                f"{a!r} / {b!r} — comparing raw values"
+            )
+
     # Lists: sort for order-independent comparison, then compare element-by-
     # element with _subset="both" (intersection mode) so that list elements
     # like audience refs {id, name} are compared only on keys both sides

--- a/adopt/adopt/facebook/test_probe.py
+++ b/adopt/adopt/facebook/test_probe.py
@@ -1,0 +1,138 @@
+from typing import Dict
+
+from . import field_contract
+from .probe import (
+    DIFFERS,
+    DROPPED,
+    OK,
+    classify,
+    render_dropped_block,
+    summarise,
+    update_contract,
+)
+
+FIELDS = ["object_story_spec", "url_tags", "degrees_of_freedom_spec"]
+
+
+def test_classify_reports_matching_leaves_as_ok():
+    desired = {"url_tags": "ref=foo", "object_story_spec": {"page_id": "111"}}
+    source = {"url_tags": "ref=foo", "object_story_spec": {"page_id": "111"}}
+
+    verdicts = {p: v for p, v, _, _ in classify(desired, source, FIELDS)}
+
+    assert verdicts == {".url_tags": OK, ".object_story_spec.page_id": OK}
+
+
+def test_classify_reports_a_key_facebook_did_not_return_as_dropped():
+    desired = {
+        "degrees_of_freedom_spec": {
+            "creative_features_spec": {"image_text_translation": {"enroll_status": "OPT_IN"}}
+        }
+    }
+    source = {
+        "degrees_of_freedom_spec": {
+            "creative_features_spec": {"standard_enhancements": {"enroll_status": "OPT_OUT"}}
+        }
+    }
+
+    findings = classify(desired, source, FIELDS)
+    path = ".degrees_of_freedom_spec.creative_features_spec.image_text_translation"
+
+    assert (path, DROPPED) in [(p, v) for p, v, _, _ in findings]
+
+
+def test_classify_reports_changed_values_as_differs():
+    findings = classify({"url_tags": "ref=new"}, {"url_tags": "ref=old"}, FIELDS)
+
+    assert findings == [(".url_tags", DIFFERS, "ref=new", "ref=old")]
+
+
+def test_classify_ignores_extra_keys_from_facebook():
+    # Facebook returns far more than we set; only what we send is our business.
+    desired = {"object_story_spec": {"page_id": "111"}}
+    source = {"object_story_spec": {"page_id": "111", "server_thing": "x"}}
+
+    assert [v for _, v, _, _ in classify(desired, source, FIELDS)] == [OK]
+
+
+def test_classify_treats_reordered_lists_as_equal():
+    # Facebook reorders list values; _eq sorts before comparing, so must we.
+    desired = {"object_story_spec": {"tags": [{"id": "2"}, {"id": "1"}]}}
+    source = {"object_story_spec": {"tags": [{"id": "1"}, {"id": "2"}]}}
+
+    assert [v for _, v, _, _ in classify(desired, source, FIELDS)] == [OK]
+
+
+def test_summarise_separates_declared_from_undeclared_drops():
+    declared = ".degrees_of_freedom_spec.creative_features_spec.image_text_translation"
+    findings = [
+        (declared, DROPPED, {"enroll_status": "OPT_IN"}, None),
+        (".url_tags", DROPPED, "ref=foo", None),
+    ]
+
+    rows = summarise(findings)
+
+    assert rows[declared]["declared_dropped"] is True
+    assert rows[".url_tags"]["declared_dropped"] is False
+
+
+def test_summarise_flags_a_declaration_facebook_now_honours_as_stale():
+    declared = ".degrees_of_freedom_spec.creative_features_spec.image_text_translation"
+
+    rows = summarise([(declared, OK, {"enroll_status": "OPT_IN"}, {"enroll_status": "OPT_IN"})])
+
+    assert rows[declared]["verdict"] == "stale"
+
+
+def test_summarise_reports_a_path_dropped_on_any_ad():
+    # One clean ad does not make the field safe to compare.
+    rows = summarise([(".url_tags", OK, "a", "a"), (".url_tags", DROPPED, "a", None)])
+
+    assert rows[".url_tags"]["verdict"] == DROPPED
+
+
+def test_rendered_block_is_valid_python_and_round_trips():
+    paths = {
+        "a.b.c": "short reason",
+        "d.e": "a much longer reason " * 8,
+    }
+
+    ns: Dict = {"Dict": Dict}
+    exec(render_dropped_block(paths), ns)
+
+    assert set(ns["DROPPED"]) == set(paths)
+    # Reasons survive wrapping intact apart from whitespace normalisation.
+    assert " ".join(ns["DROPPED"]["d.e"].split()) == " ".join(paths["d.e"].split())
+
+
+def test_update_contract_adds_undeclared_drops():
+    rows = {
+        ".url_tags": {"verdict": DROPPED, "declared_dropped": False, "ads": 3, "hits": 3},
+    }
+
+    new = update_contract(rows, "2026-07-31")
+
+    assert new is not None
+    assert '"url_tags"' in new
+    assert "2026-07-31" in new
+    # The existing declaration is preserved.
+    assert "image_text_translation" in new
+
+
+def test_update_contract_removes_stale_declarations():
+    declared = next(iter(field_contract.DROPPED))
+    rows = {f".{declared}": {"verdict": "stale", "declared_dropped": True, "ads": 1, "hits": 1}}
+
+    new = update_contract(rows, "2026-07-31")
+
+    assert new is not None
+    assert declared not in new
+
+
+def test_update_contract_is_a_noop_when_nothing_changed():
+    rows = {
+        f".{p}": {"verdict": DROPPED, "declared_dropped": True, "ads": 1, "hits": 1}
+        for p in field_contract.DROPPED
+    }
+
+    assert update_contract(rows, "2026-07-31") is None

--- a/adopt/adopt/facebook/test_reconciliation.py
+++ b/adopt/adopt/facebook/test_reconciliation.py
@@ -847,6 +847,61 @@ def test_eq_warns_about_undeclared_drop(caplog):
     assert "adopt-probe" in caplog.text
 
 
+def test_eq_treats_facebook_string_budget_as_equal_to_our_int():
+    # Facebook returns daily_budget as a string, create_adset sets an int.
+    # Same number, so the adset must not be rewritten. Without normalising,
+    # '2585' != 2585 and EVERY adset is rewritten on EVERY run forever.
+    live = _adobject({"name": "s1", "daily_budget": "2585"}, AdSet)
+    desired = _adobject({"name": "s1", "daily_budget": 2585}, AdSet)
+
+    assert _eq(live, desired, ["name", "daily_budget"])
+
+
+def test_eq_still_detects_a_real_budget_change():
+    # Normalising must not blind us to the optimizer actually moving money.
+    live = _adobject({"name": "s1", "daily_budget": "2585"}, AdSet)
+    desired = _adobject({"name": "s1", "daily_budget": 3000}, AdSet)
+
+    assert not _eq(live, desired, ["name", "daily_budget"])
+
+
+def test_eq_treats_equivalent_end_times_as_equal():
+    # Facebook returns an ISO string in the ad account's timezone; create_adset
+    # sets a naive UTC datetime. 02:00+0200 is 00:00 UTC — the same instant.
+    live = _adobject({"name": "s1", "end_time": "2026-08-03T02:00:00+0200"}, AdSet)
+    desired = _adobject({"name": "s1", "end_time": datetime(2026, 8, 3, 0, 0)}, AdSet)
+
+    assert _eq(live, desired, ["name", "end_time"])
+
+
+def test_eq_still_detects_a_real_end_time_change():
+    live = _adobject({"name": "s1", "end_time": "2026-08-03T02:00:00+0200"}, AdSet)
+    desired = _adobject({"name": "s1", "end_time": datetime(2026, 8, 5, 0, 0)}, AdSet)
+
+    assert not _eq(live, desired, ["name", "end_time"])
+
+
+def test_update_adset_no_ops_when_only_representation_differs():
+    # End-to-end: the live adset and the desired one mean the same thing and
+    # differ only in how Facebook renders them. No instruction may be emitted.
+    common = {
+        "name": "gender:men,geography:country",
+        "targeting": {"age_min": 36, "age_max": 65},
+        "status": "ACTIVE",
+        "optimization_goal": "CONVERSATIONS",
+    }
+    live = _adobject(
+        {**common, "daily_budget": "2585", "end_time": "2026-08-03T02:00:00+0200"},
+        AdSet,
+    )
+    desired = _adobject(
+        {**common, "daily_budget": 2585, "end_time": datetime(2026, 8, 3, 0, 0)},
+        AdSet,
+    )
+
+    assert update_adset(live, desired) == []
+
+
 def test_eq_tolerates_a_whole_top_level_field_missing_from_source(caplog):
     # Deliberate asymmetry with the nested rule above, and long-standing
     # behaviour: a top-level field absent from Facebook's response is not

--- a/adopt/adopt/facebook/test_reconciliation.py
+++ b/adopt/adopt/facebook/test_reconciliation.py
@@ -1,9 +1,12 @@
+import logging
 from datetime import datetime
 from typing import TypeVar
 
 from facebook_business.adobjects.ad import Ad
+from facebook_business.adobjects.adcreative import AdCreative
 from facebook_business.adobjects.adset import AdSet
 
+from . import field_contract
 from .reconciliation import _eq, ad_dif, adset_dif, update_adset
 from .update import Instruction
 
@@ -813,9 +816,11 @@ def test_eq_still_detects_real_creative_difference_in_subset_mode():
     assert not _eq(desired_creative, source_creative, _CREATIVE_FIELDS)
 
 
-def test_eq_still_detects_missing_key_in_source_in_subset_mode():
-    # In subset mode (nested recursion), a key present in desired but missing
-    # from source is a real difference.
+def test_eq_still_detects_undeclared_key_missing_from_source():
+    # An undeclared key present in desired but missing from source stays a
+    # difference. It has to: a real change (photo_data -> link_data) looks
+    # exactly like a field Facebook silently drops, and only a human can say
+    # which one it is. See test_ad_dif_updates_when_object_story_spec_format_changes.
     source = {
         "page_id": "111",
         "link_data": {"image_hash": "abc123"},
@@ -827,6 +832,132 @@ def test_eq_still_detects_missing_key_in_source_in_subset_mode():
     }
 
     assert not _eq(desired, source, _subset="a")
+
+
+def test_eq_warns_about_undeclared_drop(caplog):
+    # Never silent: an undeclared drop is what an endless rewrite loop looks
+    # like on its first run, so it names itself and the command that fixes it.
+    source = {"link_data": {"image_hash": "abc123"}}
+    desired = {"link_data": {"image_hash": "abc123", "surprise": "new"}}
+
+    with caplog.at_level(logging.WARNING):
+        assert not _eq(desired, source, _subset="a")
+
+    assert "undeclared drop at .link_data.surprise" in caplog.text
+    assert "adopt-probe" in caplog.text
+
+
+def test_eq_tolerates_a_whole_top_level_field_missing_from_source(caplog):
+    # Deliberate asymmetry with the nested rule above, and long-standing
+    # behaviour: a top-level field absent from Facebook's response is not
+    # something we can act on, so it is skipped rather than rewritten every
+    # run. It still warns when undeclared. See _declared_drop.
+    source = {"actor_id": "111"}
+    desired = {"actor_id": "111", "url_tags": "ref=foo"}
+
+    with caplog.at_level(logging.WARNING):
+        assert _eq(desired, source, _CREATIVE_FIELDS)
+
+    assert "undeclared drop at .url_tags" in caplog.text
+
+
+def test_eq_declared_drop_is_not_a_difference():
+    # The production case: we send image_text_translation, Facebook returns
+    # ~82 creative_features_spec keys and never that one. Declared, so equal.
+    source = {
+        "degrees_of_freedom_spec": {
+            "creative_features_spec": {
+                "standard_enhancements": {"enroll_status": "OPT_OUT"},
+            }
+        }
+    }
+    desired = {
+        "degrees_of_freedom_spec": {
+            "creative_features_spec": {
+                "image_text_translation": {"enroll_status": "OPT_IN"},
+            }
+        }
+    }
+
+    assert _eq(desired, source, _CREATIVE_FIELDS)
+
+
+def test_eq_declared_drop_does_not_warn(caplog):
+    # The real production case: image_text_translation is declared in
+    # field_contract.DROPPED, so it is expected and stays quiet.
+    path = "degrees_of_freedom_spec.creative_features_spec.image_text_translation"
+    assert path in field_contract.DROPPED, "fixture depends on this declaration"
+
+    source = {
+        "degrees_of_freedom_spec": {
+            "creative_features_spec": {
+                "standard_enhancements": {"enroll_status": "OPT_OUT"},
+            }
+        }
+    }
+    desired = {
+        "degrees_of_freedom_spec": {
+            "creative_features_spec": {
+                "image_text_translation": {"enroll_status": "OPT_IN"},
+            }
+        }
+    }
+
+    with caplog.at_level(logging.WARNING):
+        assert _eq(desired, source, _CREATIVE_FIELDS)
+
+    assert "undeclared drop" not in caplog.text
+
+
+def test_ad_dif_converges_when_facebook_drops_a_declared_field():
+    # End-to-end version of the production bug: the ONLY difference between
+    # desired and live is a field Facebook never echoes back. This must
+    # produce no instruction at all, otherwise the ad is rewritten every run.
+    creative = {
+        "name": "Ad1",
+        "actor_id": "111",
+        "url_tags": "ref=creative.Ad1.form.hpvintrotriple",
+        "object_story_spec": {"page_id": "111"},
+    }
+
+    live_creative = {
+        **creative,
+        "degrees_of_freedom_spec": {
+            "creative_features_spec": {
+                # Facebook's own defaults, minus the key we sent.
+                "standard_enhancements": {"enroll_status": "OPT_OUT"},
+                "text_generation": {"enroll_status": "OPT_OUT"},
+            }
+        },
+    }
+
+    desired_creative = {
+        **creative,
+        "degrees_of_freedom_spec": {
+            "creative_features_spec": {
+                "image_text_translation": {"enroll_status": "OPT_IN"},
+            }
+        },
+    }
+
+    source = _adobject(
+        {"id": "1", "name": "Ad1", "status": "ACTIVE", "creative": live_creative}, Ad
+    )
+    desired = _adobject(
+        {"name": "Ad1", "status": "ACTIVE", "creative": desired_creative}, Ad
+    )
+
+    assert ad_dif("adset-1", [source], [desired]) == []
+
+
+def test_contract_field_names_match_the_facebook_sdk():
+    # The contract keys are plain strings; make sure they are the real field
+    # names the SDK uses, so a typo cannot silently drop a field from
+    # comparison altogether.
+    for f in field_contract.COMPARED_AD:
+        assert hasattr(AdCreative.Field, f), f
+    for f in field_contract.COMPARED_ADSET:
+        assert hasattr(AdSet.Field, f), f
 
 
 # ---------------------------------------------------------------------------

--- a/adopt/adopt/facebook/test_reconciliation.py
+++ b/adopt/adopt/facebook/test_reconciliation.py
@@ -847,6 +847,70 @@ def test_eq_warns_about_undeclared_drop(caplog):
     assert "adopt-probe" in caplog.text
 
 
+def test_update_adset_ignores_server_added_fields_on_the_live_adset():
+    # The reason the desired object must be _eq's first argument: Facebook
+    # decorates what it returns with fields we never set. Compared the other
+    # way round those extras look like differences and every adset is
+    # rewritten forever.
+    common = {
+        "name": "s1",
+        "targeting": {"age_min": 36},
+        "status": "ACTIVE",
+        "daily_budget": 2585,
+        "optimization_goal": "CONVERSATIONS",
+    }
+    live = _adobject(
+        {
+            **common,
+            "daily_budget": "2585",
+            "id": "srv-1",
+            "created_time": "2026-08-01T00:00:00+0000",
+            "targeting": {"age_min": 36, "brand_safety_content_filter_levels": ["X"]},
+        },
+        AdSet,
+    )
+    desired = _adobject(common, AdSet)
+
+    assert update_adset(live, desired) == []
+
+
+def test_update_adset_ignores_empty_values_facebook_elides():
+    # add_audience_targeting always sets custom_audiences, to [] when the study
+    # has none, and Facebook omits the key entirely rather than echoing [].
+    # Asking for nothing and being shown nothing is agreement.
+    live = _adobject({"name": "s1", "targeting": {"age_min": 36}}, AdSet)
+    desired = _adobject(
+        {"name": "s1", "targeting": {"age_min": 36, "custom_audiences": []}}, AdSet
+    )
+
+    assert update_adset(live, desired) == []
+
+
+def test_update_adset_still_applies_a_newly_added_audience():
+    # The other side of that rule: asking for something non-empty and not
+    # seeing it is a real difference. Adding an audience to an adset that has
+    # none must still be applied.
+    # update_adset builds its params from every compared field, so the desired
+    # adset must carry all of them — create_adset always does.
+    base = {
+        "name": "s1",
+        "status": "ACTIVE",
+        "daily_budget": 2585,
+        "optimization_goal": "CONVERSATIONS",
+        "end_time": datetime(2026, 8, 3, 0, 0),
+    }
+    live = _adobject({**base, "targeting": {"age_min": 36}}, AdSet)
+    desired = _adobject(
+        {**base, "targeting": {"age_min": 36, "custom_audiences": [{"id": "aud-1"}]}},
+        AdSet,
+    )
+
+    instructions = update_adset(live, desired)
+
+    assert len(instructions) == 1
+    assert instructions[0].params["targeting"]["custom_audiences"] == [{"id": "aud-1"}]
+
+
 def test_eq_treats_facebook_string_budget_as_equal_to_our_int():
     # Facebook returns daily_budget as a string, create_adset sets an int.
     # Same number, so the adset must not be rewritten. Without normalising,

--- a/adopt/pyproject.toml
+++ b/adopt/pyproject.toml
@@ -46,6 +46,10 @@ types-python-jose = "^3.3.4.8"
 pandas-stubs = "^2.1.4.231218"
 pytest-asyncio = "<0.26.0"
 
+[tool.poetry.scripts]
+# Checks field_contract.py against live Facebook ads. See adopt/README.md.
+adopt-probe = "adopt.facebook.probe:main"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/planning/field-contract-production-verification.md
+++ b/planning/field-contract-production-verification.md
@@ -1,0 +1,160 @@
+# Verifying the field contract fix in production
+
+What "working" looks like after `adopt` v0.1.77 rolls out, and how to check it.
+
+The short version: **ads should stop updating almost entirely; adsets should
+keep updating, but only when the optimizer actually moves money.** If ad
+updates are still happening on every run, the fix did not land.
+
+## Measured baseline (before the fix)
+
+From a real `vlab-adopt-ads` run on v0.1.75/76, captured 2026-07-29:
+
+```
+Generated 36 instruction(s) for OWIS Nigeria Study
+Generated 2 instruction(s) for Girl Effect
+
+ad updates:                 30
+adset updates:               8
+creative mismatch warnings: 30
+```
+
+That was every run, every two hours: **38 write instructions, ~456 a day.**
+
+Not all of it was waste. Of the 8 adset updates, 7 were genuine optimizer budget
+moves. One was not:
+
+```
+_eq: mismatch at .daily_budget — desired='100' source=100
+```
+
+Same number, flagged only because Facebook returns a string and we send an int.
+That stratum sits at `min_budget`, so its budget never changes — it was rewritten
+on every run, forever, for nothing.
+
+All 30 ad updates were waste.
+
+## What to expect after
+
+| | before | after | note |
+|---|---|---|---|
+| ad updates per run | 30 | **0** | when no creative or config changed |
+| adset updates per run | 8 | **~7** | only genuine budget moves; varies by run |
+| `creative mismatch` warnings | 30 | **0** | |
+| total instructions per run | 38 | **~7** | roughly an 80% reduction |
+
+Adsets will *not* go to zero and should not be expected to. The optimizer
+recomputes budgets every run and they rarely land on the same number. What
+should disappear is the adset whose budget did not change — anything pinned at
+`min_budget`, and any run where the optimizer holds steady.
+
+Ads should be flat zero on a run where nobody edited a study. A single ad update
+after a real creative edit is correct — it should then be followed by zero on the
+next run. **An ad update repeating across consecutive runs is the failure
+signal.**
+
+## How to check
+
+The `adopt-ads` cron runs `30 */2 * * *`. Give it two or three ticks.
+
+```bash
+# newest completed adopt-ads pod
+POD=$(kubectl get pods -n vprod --no-headers --sort-by=.metadata.creationTimestamp \
+  | grep '^vlab-adopt-ads-' | tail -1 | awk '{print $1}')
+
+kubectl logs "$POD" -n vprod > /tmp/adopt-ads.log
+
+# the headline numbers
+grep -E "Generated [0-9]+ instruction" /tmp/adopt-ads.log
+echo "ad updates:    $(grep -c 'Executing: ad/update'    /tmp/adopt-ads.log)"
+echo "adset updates: $(grep -c 'Executing: adset/update' /tmp/adopt-ads.log)"
+echo "mismatches:    $(grep -c 'creative mismatch'       /tmp/adopt-ads.log)"
+```
+
+Pass condition, on a run where no study was edited:
+
+- `ad updates: 0`
+- `mismatches: 0`
+- `adset updates` ≤ the number of strata whose budget genuinely moved
+
+Compare across **three consecutive runs**, not one. One run tells you little; the
+same 30 ads updating three times running is the bug still present.
+
+### The new warning to watch for
+
+```bash
+grep 'undeclared drop' /tmp/adopt-ads.log
+```
+
+This is the fix's own alarm. It means we sent a field Facebook did not echo back,
+and it is not in `field_contract.DROPPED`. Expect **none**. If one appears:
+
+1. It names the exact path.
+2. Run `adopt-probe <study>` to confirm against live data.
+3. Decide whether it is a genuine drop (declare it) or a real change that should
+   be applied once (leave it alone — it will converge on the next run).
+
+Do not reflexively `--update`. A genuine one-time change looks identical to a
+drop; `planning/field-contract.md` has a worked example
+(`targeting.targeting_automation`) where declaring it would have been wrong.
+
+### Facebook API pressure
+
+The loops were a contributing cause of `code 17 / Ad Account Has Too Many API
+Calls` throttling. With ~80% fewer writes, backoff should become rarer:
+
+```bash
+grep -c 'Too Many API Calls' /tmp/adopt-ads.log     # expect 0, was 4
+grep -c 'Backing off'        /tmp/adopt-ads.log
+```
+
+This is a secondary signal — rate limiting depends on everything else touching
+the ad account too, so treat a non-zero count as worth a look rather than a
+failure.
+
+### Direct check with the probe
+
+Independent of the logs, and read-only:
+
+```bash
+kubectl port-forward -n vprod svc/gbv-cockroachdb-public 5432:26257 &
+
+cd adopt
+set -a; source .env; set +a
+export PG_URL='postgres://root@localhost:5432/vlab?sslmode=disable'
+
+poetry run adopt-probe "OWIS Nigeria Study"    # expect exit 0, "contract matches"
+poetry run adopt-probe "Girl Effect"           # expect exit 0
+```
+
+Point it at **active** studies only. An inactive study can never report clean —
+`end_time` is a rolling 48-hour window, so its frozen adsets always look behind.
+
+## What would mean it is not working
+
+| symptom | reading |
+|---|---|
+| ad updates > 0 on three consecutive runs, same ad names | a dropped field is still undeclared — check for `undeclared drop` |
+| adset updates on a run where no budget changed | a representation mismatch is unhandled; run the probe |
+| `undeclared drop` on an active study | Facebook's behaviour moved; investigate before declaring |
+| ads updating that were *not* updating before | the fix broke something — see rollback |
+
+## Rollback
+
+Nothing here changes what adopt sends to Facebook — only whether it decides to
+resend it. The failure mode is "still writes too much", not "writes something
+wrong". So rollback is not urgent, and is a one-line values change:
+
+```bash
+# devops/values/toixo-prod.yaml
+versionAdopt: &vadopt v0.1.76      # from v0.1.77
+
+helm upgrade vlab devops/helm -f devops/values/toixo-prod.yaml -n vprod
+```
+
+The one genuine behaviour risk is the opposite direction: a change that *should*
+be applied being treated as already-applied. The guards for that are
+`test_ad_dif_updates_when_object_story_spec_format_changes` and
+`test_update_adset_still_applies_a_newly_added_audience`. If a study edit stops
+taking effect in production, that is the thing to suspect, and it is worth
+rolling back for.

--- a/planning/field-contract.md
+++ b/planning/field-contract.md
@@ -32,6 +32,34 @@ Two things made it invisible for so long:
 - The writes all succeeded. Nothing errored, no alert fired. The only visible
   symptom was Facebook throttling reads on an unrelated study later in the run.
 
+## It was six fields, not one
+
+The first diagnosis came from diffing a single `_eq: mismatch` log line, which
+showed exactly one key missing — `image_text_translation`. Running the probe
+against all 60 live ads found five more:
+
+| field | ads sending it that Facebook dropped |
+|---|---|
+| `image_text_translation` | 30/30 |
+| `image_animation` | 3/30 |
+| `image_brightness_and_contrast` | 3/30 |
+| `image_templates` | 3/30 |
+| `image_touchups` | 3/30 |
+| `text_optimizations` | 3/30 |
+
+Re-parsing every mismatch line in the captured production log confirmed the
+same six. The study has two creative variants with different
+`creative_features_spec` templates (15 and 16 keys), and only the larger one
+carries the extra five.
+
+Declaring just `image_text_translation` would have fixed 27 ads and left 3
+rewriting forever — a quieter version of the same bug, and one that would have
+looked fixed on any dashboard counting total writes.
+
+The lesson is in the tooling, not the diagnosis: one log line is a sample, and
+a sample cannot tell you the shape of the whole. That is what `adopt-probe`
+is for.
+
 ## The fix
 
 `adopt/facebook/field_contract.py` declares:
@@ -90,6 +118,17 @@ exits non-zero while the contract and Facebook disagree.
 The probe reuses the real code path — `pair_creatives_with_destinations` then
 `create_creative` — so what it compares is what the cron would actually
 publish, not a reimplementation that can drift.
+
+## Verified against live Facebook
+
+`adopt-probe "OWIS Nigeria Study"` was run against production on 2026-08-01
+(read-only, via a port-forward to the prod database). It compared 46 field
+paths across all 60 live ads, found the six drops above, and after `--update`
+reports `contract matches live Facebook behaviour` and exits 0.
+
+That run also caught a bug the unit tests could not: `db.query` is a
+generator, so `resolve_study_id`'s `if rows:` was always truthy and passed the
+study *name* through as if it were an id. Fixture-based tests never touch it.
 
 ## What this does not cover
 

--- a/planning/field-contract.md
+++ b/planning/field-contract.md
@@ -145,16 +145,36 @@ Normalisers are hand-written, not probe-generated. A normaliser encodes what
 "the same" *means* for a field, and no amount of sampling live data can infer
 that.
 
-## Two things to be careful of near this code
+## The argument order, now unified
 
-**The argument order is reversed between the two callers.** `update_ad` calls
-`_eq(desired, live)`; `update_adset` calls `_eq(live, desired)`. Since `_eq`
-walks the *first* argument's keys and tolerates extras in the second, the two
-paths do genuinely different things. It also makes the log messages misleading
-on the adset path — `desired=` there is actually the live value. `probe_adsets`
-deliberately mirrors the production order so a clean report means the
-reconciler really will no-op. Worth unifying, but it is a behaviour change to
-reconciliation and deserves its own verification.
+`_eq(a, b)` treats `a` as the authority: every key in `a` must be present and
+equal in `b`, and extras in `b` are ignored. Facebook decorates everything it
+returns with server-side defaults we never set, so the **desired** object has
+to be `a`.
+
+`update_ad` always did that. `update_adset` had it backwards — `_eq(live,
+desired)` asks "is everything Facebook returned present in what we want?",
+which is a different question and the wrong one. Both now pass desired first.
+
+That also fixes the logging: `_eq` labels its arguments `desired=` and
+`source=`, which were simply lying on the adset path.
+
+Flipping it exposed one field: `targeting.custom_audiences`. `add_audience_targeting`
+always sets it — to `[]` when the study has no audiences — and Facebook omits
+the key rather than echoing an empty list. In the old order this was invisible.
+
+Rather than declare it dropped, `_eq` now takes **empty and absent as
+agreement**: if we ask for nothing and Facebook shows nothing, that is not a
+difference. Declaring it dropped would have been worse — a path in DROPPED is
+skipped whenever it is missing from the live object, so *adding* an audience to
+an adset that has none would have been silently never applied.
+`test_update_adset_still_applies_a_newly_added_audience` guards that.
+
+The rule is general and does not weaken the protections above: `link_data` and
+`image_text_translation` both carry non-empty values, so both still require a
+real answer.
+
+## One more thing to be careful of near this code
 
 **`hydrate_strata` mutates the strata it is given.** It appends to
 `excluded_custom_audiences` in place, so calling it twice in one process
@@ -170,9 +190,18 @@ targeting drift.
 
 ```
 ADS      compared 46 field paths across 60 live ads   -> 6 declared drops, 40 clean
-ADSETS   compared 13 field paths across 6 live adsets -> 13 clean
+ADSETS   compared 14 field paths across 6 live adsets -> 14 clean
 contract matches live Facebook behaviour.             (exit 0)
 ```
+
+And directly against the production function, with each live adset's own
+budget and status fed back in so nothing had genuinely changed:
+
+```
+6/6 adsets no-op when nothing changed
+```
+
+Before this work that number was 0/6, on every run.
 
 Running it against production caught three things no fixture-based test could:
 
@@ -195,7 +224,8 @@ logic, it can disagree with the thing it is meant to be checking. Delegate.
 - The probe feeds the live budget and status back in as the desired ones, so it
   says nothing about whether the optimizer's current budget is correct. It
   answers "does this round-trip", not "is this up to date".
-- `targeting.custom_audiences` is sent by adopt (as `[]`) and never returned by
-  Facebook. Invisible today because the adset path walks the live object's keys,
-  so it is never examined — but it would surface immediately if the argument
-  order above were unified.
+- Removing the last audience from an adset that has some is still applied
+  (both sides present, values differ), but the empty-and-absent rule means we
+  cannot tell "we want none" from "we never asked" when Facebook has none
+  either. That is the correct outcome here and worth remembering if the rule
+  is ever reused for a field where absent and empty differ in meaning.

--- a/planning/field-contract.md
+++ b/planning/field-contract.md
@@ -216,6 +216,52 @@ Running it against production caught three things no fixture-based test could:
 The last one is the general lesson: anywhere the probe reimplements comparison
 logic, it can disagree with the thing it is meant to be checking. Delegate.
 
+## What probing 45 studies found
+
+Run read-only on 2026-08-01 across every study with an end date in the previous
+twelve months: 2 active, 43 historical. 42 of the 43 historical studies were
+reachable — no expired tokens anywhere, including a study that ended a year
+earlier. Probing old studies works. No rate limiting was hit in 45 sequential
+runs.
+
+**Only the two active studies came back clean.** Everything else showed at
+least one difference, and neither category is a contract problem:
+
+### `.targeting.targeting_automation` is not a drop — do not declare it
+
+It appeared as an undeclared drop in 26 studies, every one ending 2026-02-26 or
+earlier, and in none from 2026-04-10 onward. That boundary is the point:
+`create_adset` now forces `targeting_automation = {"advantage_audience": 0}` on
+every adset unconditionally. Adsets built before that policy simply do not have
+the field set on Facebook's side.
+
+So this is a **real difference that should be applied once**, not a field
+Facebook refuses to echo. The live adsets of both active studies *do* carry
+`targeting_automation`, which is exactly what proves it round-trips: once
+written, Facebook returns it, and the comparison converges.
+
+Declaring it in DROPPED would have been a bad mistake — a DROPPED path is
+skipped whenever it is missing from the live object, so we would permanently
+stop applying "Advantage+ Audience off" to any adset that lacks it. That is a
+real targeting setting on real spend. This is the same shape as the
+photo_data → link_data case: a genuine change wearing the costume of a drop.
+
+It also costs nothing today. All 26 studies are inactive, and `get_active_studies`
+means the cron never touches them.
+
+### `end_time` always differs on inactive studies, by construction
+
+`create_adset` sets `end_time` to *today's* midnight plus `ADSET_HOURS` (48), a
+rolling window pushed forward on every run. An inactive study's live adsets are
+frozen wherever the cron last left them, so the desired value is always "two
+days from now" and the live one is always older. 34 studies showed this, all
+with an identical `want` regardless of study age.
+
+Nothing is wrong. It does mean **a probe report on an inactive study will never
+be clean**, and that `end_time` diff carries no information. Worth knowing
+before anyone wires the probe's exit code into a scheduled check across all
+studies rather than active ones.
+
 ## What this does not cover
 
 - The contract is a flat path namespace shared by ads and adsets. `daily_budget`

--- a/planning/field-contract.md
+++ b/planning/field-contract.md
@@ -119,23 +119,83 @@ The probe reuses the real code path — `pair_creatives_with_destinations` then
 `create_creative` — so what it compares is what the cron would actually
 publish, not a reimplementation that can drift.
 
+## The adsets were worse
+
+Extending the probe to adsets found a second, independent loop — and a
+deterministic one. Feeding the live adset's own budget back in as the desired
+budget, so the optimizer's intended change could not mask anything, an adset
+*still* compared unequal on every field that matters:
+
+| field | Facebook returns | adopt sends |
+|---|---|---|
+| `daily_budget` | `'2585'` (str) | `2585` (int) |
+| `end_time` | `'2026-08-03T02:00:00+0200'` (str) | `datetime(2026, 8, 3, 0, 0)` (naive) |
+
+Same number. Same instant. Different types, so `==` is False forever. Unlike
+the ad case, which needed a particular creative template to trigger, this hits
+**every adset on every run unconditionally** — 6 for OWIS plus 2 for Girl
+Effect, every two hours, whether or not anything changed.
+
+`field_contract.NORMALIZE` fixes this: a per-path function that canonicalises
+both sides before comparison. `daily_budget` through `int`, `end_time` to a UTC
+instant. Genuine changes still register — `int('2585') != int(3000)` — which is
+what `test_eq_still_detects_a_real_budget_change` guards.
+
+Normalisers are hand-written, not probe-generated. A normaliser encodes what
+"the same" *means* for a field, and no amount of sampling live data can infer
+that.
+
+## Two things to be careful of near this code
+
+**The argument order is reversed between the two callers.** `update_ad` calls
+`_eq(desired, live)`; `update_adset` calls `_eq(live, desired)`. Since `_eq`
+walks the *first* argument's keys and tolerates extras in the second, the two
+paths do genuinely different things. It also makes the log messages misleading
+on the adset path — `desired=` there is actually the live value. `probe_adsets`
+deliberately mirrors the production order so a clean report means the
+reconciler really will no-op. Worth unifying, but it is a behaviour change to
+reconciliation and deserves its own verification.
+
+**`hydrate_strata` mutates the strata it is given.** It appends to
+`excluded_custom_audiences` in place, so calling it twice in one process
+duplicates entries. The probe hit this immediately — hydrating separately for
+ads and adsets invented a difference that did not exist — and now hydrates once
+and shares. Anything calling it more than once per process will see phantom
+targeting drift.
+
 ## Verified against live Facebook
 
 `adopt-probe "OWIS Nigeria Study"` was run against production on 2026-08-01
-(read-only, via a port-forward to the prod database). It compared 46 field
-paths across all 60 live ads, found the six drops above, and after `--update`
-reports `contract matches live Facebook behaviour` and exits 0.
+(read-only, via a port-forward to the prod database):
 
-That run also caught a bug the unit tests could not: `db.query` is a
-generator, so `resolve_study_id`'s `if rows:` was always truthy and passed the
-study *name* through as if it were an id. Fixture-based tests never touch it.
+```
+ADS      compared 46 field paths across 60 live ads   -> 6 declared drops, 40 clean
+ADSETS   compared 13 field paths across 6 live adsets -> 13 clean
+contract matches live Facebook behaviour.             (exit 0)
+```
+
+Running it against production caught three things no fixture-based test could:
+
+- `db.query` is a generator, so `resolve_study_id`'s `if rows:` was always
+  truthy and passed the study *name* through as if it were an id.
+- Hydrating strata separately for ads and adsets duplicated audience
+  exclusions and invented a targeting difference.
+- The probe's own list comparison was stricter than `_eq`'s, flagging reordered
+  audience refs that the reconciler ignores. `_walk` now delegates lists and
+  scalars to `_eq` itself rather than reimplementing them.
+
+The last one is the general lesson: anywhere the probe reimplements comparison
+logic, it can disagree with the thing it is meant to be checking. Delegate.
 
 ## What this does not cover
 
-- Only ads are probed today. Adset fields are declared in `COMPARED_ADSET` but
-  the probe does not fetch and classify live adsets yet.
-- The contract is a flat path namespace shared by ads and adsets. If a path
-  ever collides between them, it needs splitting per object type.
-- `daily_budget` legitimately differs on most runs (the optimizer moves it).
-  The probe reports that as `differs`, which is correct but noisy — it is a
-  real, intended, once-per-run change rather than drift.
+- The contract is a flat path namespace shared by ads and adsets. `daily_budget`
+  and `end_time` happen to be adset-only, but a path that means different things
+  on the two object types would need the namespace split.
+- The probe feeds the live budget and status back in as the desired ones, so it
+  says nothing about whether the optimizer's current budget is correct. It
+  answers "does this round-trip", not "is this up to date".
+- `targeting.custom_audiences` is sent by adopt (as `[]`) and never returned by
+  Facebook. Invisible today because the adset path walks the live object's keys,
+  so it is never examined — but it would surface immediately if the argument
+  order above were unified.

--- a/planning/field-contract.md
+++ b/planning/field-contract.md
@@ -1,0 +1,102 @@
+# The Facebook field contract
+
+> Why this exists: on 2026-07-30 we found adopt rewriting the same 30 ads every
+> two hours, indefinitely, because of one field Facebook accepts but never
+> returns. ~360 no-op ad writes a day against a single ad account, and a
+> contributing cause of `code 17 / Ad Account Has Too Many API Calls`.
+
+## What happened
+
+`reconciliation._eq` compares the live ad against the ad the study config
+describes, and `update_ad` rewrites the whole ad if they differ.
+
+The OWIS Nigeria study's creative template sets:
+
+```
+degrees_of_freedom_spec.creative_features_spec.image_text_translation = {"enroll_status": "OPT_IN"}
+```
+
+Facebook accepts that write, then returns ~82 `creative_features_spec` keys of
+which `image_text_translation` is not one. Every other key matched exactly.
+
+`_eq`'s nested subset mode said "a key in desired that is missing from source
+IS a difference" and returned `False`. So: rewrite the ad, Facebook drops the
+key again, next run sees the same difference. Three consecutive cron runs were
+confirmed pushing the identical 30 ad updates; there was no reason it would
+ever stop.
+
+Two things made it invisible for so long:
+
+- The per-ad log line was `WARNING ... creative mismatch`, which reads like the
+  reconciler working correctly rather than looping.
+- The writes all succeeded. Nothing errored, no alert fired. The only visible
+  symptom was Facebook throttling reads on an unrelated study later in the run.
+
+## The fix
+
+`adopt/facebook/field_contract.py` declares:
+
+- `COMPARED_AD` / `COMPARED_ADSET` — which fields participate in the comparison
+  and, in a sentence each, why. Previously these were bare lists in
+  `reconciliation.py` with no rationale, so nobody could tell whether a given
+  field was load-bearing.
+- `DROPPED` — fields Facebook accepts but does not echo back. Excluded from
+  comparison.
+
+## Why undeclared drops are still differences
+
+The obvious fix — never treat a missing key as a difference — is wrong, and
+`test_ad_dif_updates_when_object_story_spec_format_changes` proves it. When a
+creative is migrated from `photo_data` to `link_data`, the live object is
+missing `link_data` in exactly the same shape as a field Facebook drops:
+a dict-valued key present in desired, absent from source.
+
+There is no signal in the data separating "Facebook won't store this" from
+"this is a real change we must apply". So tolerance is opt-in per field, and an
+undeclared drop warns with the path and the command that resolves it:
+
+```
+WARNING _eq: undeclared drop at .degrees_of_freedom_spec.creative_features_spec.foo
+        — we set this field but Facebook did not return it. ...
+        Check with `adopt-probe <study>` and declare it in field_contract.DROPPED.
+```
+
+That warning is worth alerting on: a fresh one means either a real migration in
+flight or a new rewrite loop starting.
+
+### The top-level exception
+
+This rule applies to *nested* keys. At the top level — a whole declared field
+like `url_tags` or `object_story_spec` missing from Facebook's response —
+`_eq` skips instead, which is what it has always done. A field Facebook does
+not return at all gives us nothing to act on, and making it a difference would
+start exactly the rewrite loop this work exists to kill. It still warns when
+undeclared.
+
+Pinned by `test_eq_tolerates_a_whole_top_level_field_missing_from_source`, so
+the asymmetry is deliberate rather than an accident waiting to be "tidied up".
+
+## Maintaining it
+
+```bash
+poetry run adopt-probe <study>            # report
+poetry run adopt-probe <study> --update   # rewrite DROPPED, stamped with today
+```
+
+Run it when Facebook ships API changes, when a study starts using creative
+options it hasn't before, or when the `undeclared drop` warning appears. It
+exits non-zero while the contract and Facebook disagree.
+
+The probe reuses the real code path — `pair_creatives_with_destinations` then
+`create_creative` — so what it compares is what the cron would actually
+publish, not a reimplementation that can drift.
+
+## What this does not cover
+
+- Only ads are probed today. Adset fields are declared in `COMPARED_ADSET` but
+  the probe does not fetch and classify live adsets yet.
+- The contract is a flat path namespace shared by ads and adsets. If a path
+  ever collides between them, it needs splitting per object type.
+- `daily_budget` legitimately differs on most runs (the optimizer moves it).
+  The probe reports that as `differs`, which is correct but noisy — it is a
+  real, intended, once-per-run change rather than drift.


### PR DESCRIPTION
## The bugs

adopt rewrote the same ads and adsets on every 2-hourly run, indefinitely, because certain fields could never compare equal. Two independent causes:

**1. Fields Facebook accepts but never echoes back.** The OWIS creative template sets `degrees_of_freedom_spec.creative_features_spec.image_text_translation`; Facebook accepts the write, then returns ~82 keys never including that one. `_eq` treated "key in desired, missing from source" as a difference, so: rewrite, Facebook drops it, next run sees the same difference. ~360 no-op ad writes a day against one ad account, and a contributing cause of `code 17 / Ad Account Has Too Many API Calls` throttling.

**2. Fields Facebook returns in a different representation.** Feeding an adset's own live budget back in as the desired budget, it *still* compared unequal:

| field | Facebook returns | adopt sends |
|---|---|---|
| `daily_budget` | `'2585'` (str) | `2585` (int) |
| `end_time` | `'2026-08-03T02:00:00+0200'` | `datetime(2026, 8, 3, 0, 0)` |

Same number, same instant, different types. This hit **every adset on every run unconditionally** — 8 per run across two active studies, whether or not anything changed.

Both went unnoticed because every write succeeded. Nothing errored, no alert fired, and the per-ad log line reads as the reconciler working rather than looping.

## The fix

`adopt/facebook/field_contract.py` declares, with rationale per field:

- `COMPARED_AD` / `COMPARED_ADSET` — which fields participate in the comparison and why (previously bare lists with no rationale)
- `DROPPED` — fields Facebook accepts but never returns; excluded from comparison
- `NORMALIZE` — per-path canonicalisers so representation differences are not mistaken for drift

Plus two rules in `_eq`:

- **Tolerance is declared, never inferred.** A real change — converting a creative from `photo_data` to `link_data` — leaves the live object missing `link_data` in exactly the same shape as a dropped field. Nothing in the data separates them, so an undeclared drop stays a difference and warns with the path and the command that resolves it.
- **Empty and absent are agreement.** Facebook elides empty values rather than echoing them. Asking for something non-empty and not seeing it is still a difference, so adding an audience is never swallowed.

**Argument order unified.** `_eq(a, b)` treats `a` as the authority — everything in it must match `b`, extras in `b` ignored. Facebook decorates responses with server defaults we never set, so desired must come first. `update_ad` did this; `update_adset` passed `_eq(live, desired)`, asking the wrong question. Both now pass desired first, which also fixes `_eq`'s log labels, previously lying on the adset path.

## `adopt-probe`

```
adopt-probe <study>            # read-only report
adopt-probe <study> --update   # rewrite DROPPED, stamped with today
```

Builds the creative and adset a study's config asks for via the real code path, fetches the live ones, and classifies every field as `ok` / `dropped` / `differs` / `stale`. Exits non-zero while the contract and Facebook disagree.

## Verification

Run read-only against production across **45 studies** (2 active, 43 historical to 2025-08-15):

- Both active studies clean, exit 0 — 46 field paths across 60 live ads, 14 across 6 live adsets
- Calling `update_adset` directly with each live adset's own budget and status: **6/6 no-op**. That was 0/6 before this branch.
- 42 of 43 historical studies reachable; no expired tokens, no rate limiting in 45 sequential runs

The sweep found `.targeting.targeting_automation` absent on 26 studies — and it is deliberately **not** declared. All 26 end 2026-02-26 or earlier; the boundary is `dfd5f766` (Apr 5), when `create_adset` began forcing `advantage_audience: 0`. Those adsets never had the field. Both active studies' live adsets carry it, so it round-trips once written. Declaring it would have permanently stopped enforcing Advantage+ Audience off on any adset lacking it.

Also documented: `end_time` is a rolling 48-hour window, so an inactive study can never report clean. Background in `planning/field-contract.md`.

## Tests

464 pass. The existing adset tests passed in *both* argument orders, so the direction was never covered — added tests for what the correct order buys, plus the normalisers, the empty-value rule, and end-to-end convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)