### PR TITLE
Land the ad_attributions migrations on main

### DIFF
--- a/devops/helm/migrations/init.sql
+++ b/devops/helm/migrations/init.sql
@@ -111,3 +111,35 @@ CREATE TABLE study_run_events (
 CREATE INDEX idx_study_run_events_group
   ON study_run_events (study_id, source, fingerprint, occurred_at DESC)
   STORING (event_type, severity, message, details);
+
+-- NOTE: Every future schema change to ad_attributions touches both paths
+-- (golang-migrate under devops/migrations/ AND this init.sql).
+--
+-- The ad -> stratum mapping vlab writes at ad-creation time and joins against
+-- later, replacing the dotted ref that used to ride inside every message.
+-- Three invariants, all load-bearing (planning/ad-id-attribution.md):
+--   1. `metadata` is the full ref-equivalent blob `{"creative": name, **md}`,
+--      NOT stratum.metadata -- that would silently drop the `creative` and
+--      `form` keys and miscount strata.
+--   2. Append-only: never deleted, never rebuilt from live Facebook state.
+--      Respondents keep arriving from deleted ads via reshared page posts, so
+--      a row must outlive its ad. Hence no TTL and no FK to studies -- a
+--      cascading delete is a delete path and this table has none.
+--   3. `metadata` is frozen at creation. Confs mutate; the row is a snapshot,
+--      not a pointer. Writes are ON CONFLICT DO NOTHING.
+CREATE TABLE ad_attributions (
+       network       STRING      NOT NULL DEFAULT 'facebook', -- ad network, NOT messaging channel
+       ad_id         STRING      NOT NULL,
+       study_id      UUID        NOT NULL,                    -- no FK: see invariant 2
+       stratum_id    STRING      NOT NULL,                    -- == the adset name
+       creative_name STRING      NOT NULL,                    -- == the ad name
+       shortcode     STRING,                                  -- NULL for web/app destinations
+       metadata      JSONB       NOT NULL,
+       resolved_from STRING,                                  -- 'ad_id' | 'source_id'
+       ref_token     STRING,                                  -- encoded-ref join key; NULL unless ref_mode is "encoded"
+       created       TIMESTAMPTZ NOT NULL DEFAULT now(),
+       CONSTRAINT ad_attributions_pk PRIMARY KEY (network, ad_id)
+);
+
+CREATE INDEX idx_ad_attributions_study ON ad_attributions (study_id);
+

--- a/devops/migrations/20260816000000_add_ad_attributions.down.sql
+++ b/devops/migrations/20260816000000_add_ad_attributions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS ad_attributions;

--- a/devops/migrations/20260816000000_add_ad_attributions.up.sql
+++ b/devops/migrations/20260816000000_add_ad_attributions.up.sql
@@ -1,0 +1,47 @@
+-- NOTE: Every future schema change to ad_attributions touches both paths
+-- (golang-migrate here AND devops/helm/migrations/init.sql).
+--
+-- vlab owns the ad -> stratum join. vlab creates exactly one ad per
+-- (creative, stratum) pair, so the ad id already determines the shortcode,
+-- the creative and the stratum metadata. This table is that mapping, written
+-- once at ad-creation time and joined against later, replacing the dotted ref
+-- string that used to ride to the survey platform inside every message.
+--
+-- Three invariants hold this table up. All three are load-bearing; see
+-- planning/ad-id-attribution.md.
+--
+-- 1. `metadata` is the complete key/value set the ref would have carried --
+--    `{"creative": <creative_name>, **md}` where md is what create_creative
+--    builds and hands to make_ref. It is NOT stratum.metadata: that omits the
+--    `creative` and `form` keys, and a downstream extraction conf asking for
+--    either would silently match no stratum and the optimizer would reallocate
+--    budget away from it.
+--
+-- 2. Append-only. Never delete a row, never rebuild the table from live
+--    Facebook state. Reconciliation deletes ads that fall out of the desired
+--    set, but respondents keep arriving from deleted ads -- CTWA referrals
+--    carry ads_context_data.post_id and page posts persist and can be reshared
+--    indefinitely. A row must outlive its ad. Hence: no TTL (unlike
+--    study_run_events) and no FOREIGN KEY to studies, because a cascading
+--    delete is a delete path and this table has none.
+--
+-- 3. `metadata` is frozen at creation, permanently. Study confs mutate, so a
+--    stratum's metadata today is not what it was when the ad was created --
+--    which is why even a live ad cannot be resolved by reading the current
+--    conf. The row is a snapshot, not a pointer. Writes use ON CONFLICT DO
+--    NOTHING so a re-run can never overwrite the original snapshot.
+CREATE TABLE ad_attributions (
+       network       STRING      NOT NULL DEFAULT 'facebook', -- ad network, NOT messaging channel: messenger and whatsapp ads are both 'facebook'
+       ad_id         STRING      NOT NULL,                    -- the id Meta returned when we created the ad
+       study_id      UUID        NOT NULL,                    -- no FK: see invariant 2
+       stratum_id    STRING      NOT NULL,                    -- == the adset name
+       creative_name STRING      NOT NULL,                    -- == the ad name
+       shortcode     STRING,                                  -- routing token; NULL for web/app destinations
+       metadata      JSONB       NOT NULL,                    -- frozen ref-equivalent blob: see invariant 1
+       resolved_from STRING,                                  -- which id source produced ad_id: 'ad_id' | 'source_id'
+       created       TIMESTAMPTZ NOT NULL DEFAULT now(),
+       CONSTRAINT ad_attributions_pk PRIMARY KEY (network, ad_id)
+);
+
+-- The join the CSV export and swoosh both need: every ad for one study.
+CREATE INDEX idx_ad_attributions_study ON ad_attributions (study_id);

--- a/devops/migrations/20260818000000_add_ad_attributions_ref_token.down.sql
+++ b/devops/migrations/20260818000000_add_ad_attributions_ref_token.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ad_attributions DROP COLUMN IF EXISTS ref_token;

--- a/devops/migrations/20260818000000_add_ad_attributions_ref_token.up.sql
+++ b/devops/migrations/20260818000000_add_ad_attributions_ref_token.up.sql
@@ -1,0 +1,32 @@
+-- NOTE: Every schema change to ad_attributions touches both paths (golang-migrate
+-- here AND devops/helm/migrations/init.sql).
+--
+-- The join key for ads whose ref carries one. See documentation/ad-attributions.md
+-- and adopt/adopt/ref_encoding.py for the format.
+--
+-- Why a second key rather than reusing ad_id. ad_id only attributes a respondent
+-- if Meta told fly which ad they came from, and on Messenger Meta does that for
+-- only ~31% of ad entrants -- it does not send the referral webhook for the rest
+-- (measured; documentation/recruitment-arrival-health.md). The token rides a
+-- carrier vlab authors instead, so it arrives for everyone.
+--
+-- NULL is the normal case, and it means something: this ad's ref carries no
+-- token, because its destination is not in ref_mode "encoded". It is not a gap
+-- in the record, which is why there is no NOT NULL and no default.
+--
+-- The two keys are never a fallback for one another. Which one attributes a
+-- respondent is fixed when the ad is built, not chosen at read time by whichever
+-- lookup happens to hit -- a runtime choice would make a miss indistinguishable
+-- from a mechanism switch and every debugging session an archaeology exercise.
+ALTER TABLE ad_attributions ADD COLUMN IF NOT EXISTS ref_token STRING;
+
+-- No index on ref_token, deliberately. Every read of this table is per study --
+-- get_ad_attributions loads a study's whole set and swoosh joins in memory (see
+-- documentation/ad-attributions.md, "Where the database touch lives"), so no
+-- query ever filters on the token and an index would only cost writes.
+--
+-- Nor is it UNIQUE. Uniqueness is asserted per campaign at instruction-generation
+-- time (marketing.assert_ref_tokens_unique), where the failure is a config error
+-- someone can still fix. A constraint would instead abort the INSERT *after* the
+-- ad exists on Facebook and is spending -- and this table is append-only with
+-- ON CONFLICT DO NOTHING, so a write must never fail a run.


### PR DESCRIPTION
## Why this is separate

The `vlab-migrations` image bakes `devops/migrations/` at build time, so a
`vlab-migrations-v0.2.0` tag can only be honest if the SQL is on `main`. Both
migrations here have lived only on `feature/multi-destination` since
2026-08-16.

Verified against the live cluster today:

```
schema_migrations.version = 20260718000000     # exactly what v0.1.0 contains
information_schema.tables → no ad_attributions
```

So prod has **no `ad_attributions` table**, and nobody applied it by hand. The
pinned image in `toixo-prod.yaml` (`v0.1.0`) predates both files.

## What is in it

The 5 files are the complete `devops/` diff between `main` and
`feature/multi-destination` — 113 insertions, all additive:

| File | What |
|---|---|
| `20260816000000_add_ad_attributions.{up,down}.sql` | creates the table |
| `20260818000000_add_ad_attributions_ref_token.{up,down}.sql` | adds the encoded-ref join key |
| `devops/helm/migrations/init.sql` | the fresh-cluster path, which must mirror the migrated one |

`init.sql` declares `ref_token` inline on the table rather than as a second
step, so a newly initialised cluster and a migrated one end up identical.

## Why it is safe to land alone

Nothing reads the table yet. adopt does not write it and swoosh does not join
it until the multi-destination stack lands, so this is inert on its own. That
is the point: it lets the pre-upgrade migration hook run and be verified
before it is carrying anything that matters.

Ordering still holds afterwards — swoosh's `GetAdAttributions` selects
`ref_token` unconditionally for *every* study and the error is fatal to the
run, so the column must exist before swoosh ships. This puts it there first.

## Rollout

1. merge
2. `make release SERVICE=vlab-migrations VERSION=v0.2.0`
3. bump `toixo-prod.yaml` `migrations.tag` → `v0.2.0`
4. `helm upgrade vlab devops/helm -f devops/values/toixo-prod.yaml -n vprod`

The hook is `pre-upgrade`, weight `-10`, `backoffLimit: 0`, so a bad migration
aborts the upgrade before any pod rolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HooztAJBGuViFhXTbFcxBj