### PR TITLE
Pin vlab-migrations v0.2.0 in prod

### DIFF
--- a/devops/values/toixo-prod.yaml
+++ b/devops/values/toixo-prod.yaml
@@ -7,7 +7,7 @@ versionAdopt: &vadopt v0.1.77
 # before this bump — cut it with `make release SERVICE=vlab-migrations VERSION=...`.
 migrations:
   image: ghcr.io/vlab-research/vlab-migrations
-  tag: v0.1.0
+  tag: v0.2.0
 
 # CockroachDB target for the migration hook. The vlab release borrows the gbv
 # release's cluster; that coupling is explicit here, not buried in a template.


### PR DESCRIPTION
One line: `toixo-prod.yaml` `migrations.tag` `v0.1.0` → `v0.2.0`.

`v0.1.0` contained migrations only through `20260718000000` — exactly where
prod sat, which is why `ad_attributions` had never been created. `v0.2.0` was
cut from #242's merge commit and carries `20260816000000` and `20260818000000`.

Image verified pullable by `scripts/release.sh`:
`ghcr.io/vlab-research/vlab-migrations:v0.2.0`
([run](https://github.com/vlab-research/vlab/actions/runs/32418046644))

## Pre-flight

Against a scratch CockroachDB **v24.1.28** (prod's version — v22.2.0 fails an
unrelated earlier migration on `foreign keys from table with TTL`, so matching
mattered):

- stepped to `20260718000000` to reproduce prod, then `up` applied both
  migrations cleanly to `20260818000000`, not dirty
- `down 2` rolls back cleanly, table gone, no dirty flag; `up` re-applies
- the migrated table and the one `init.sql` builds on a fresh cluster are
  identical, column for column and index for index

## Blast radius

`helm template` against this values file, diffed object-by-object against the
live `helm get manifest` for `vlab` in `vprod`:

```
only in NEW:      vlab-apply-migrations (the hook Job)
only in OLD:      none
CHANGED objects:  none
```

No workload spec changes, so nothing rolls. The upgrade is the migration and
nothing else — which is the point of landing it before the multi-destination
stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HooztAJBGuViFhXTbFcxBj