### PR TITLE
Prod: adopt v0.1.78, swoosh v0.1.10

### DIFF
--- a/devops/values/toixo-prod.yaml
+++ b/devops/values/toixo-prod.yaml
@@ -1,4 +1,4 @@
-versionAdopt: &vadopt v0.1.77
+versionAdopt: &vadopt v0.1.78
 
 # Schema migrations. The pre-upgrade hook (devops/helm/templates/migrations.yaml)
 # runs this image's `migrate up` against the DB below before new pods roll.
@@ -127,7 +127,7 @@ cronjobs:
     schedule: "30 * * * *"
     image:
       repository: "ghcr.io/vlab-research/swoosh"
-      tag: "v0.1.9"
+      tag: "v0.1.10"
       pullPolicy: Always
   - name: adopt-ads
     schedule: "30 */2 * * *"


### PR DESCRIPTION
Two-line values bump deploying #244.

Both images verified pullable by `scripts/release.sh` before the bump.

Rendered-manifest diff against live `helm get manifest` — six image lines plus the hook:

| Object | Kind | Change |
|---|---|---|
| `vlab-conf-dashboard` | **Deployment** | adopt v0.1.77 → v0.1.78, **rolls now** |
| `vlab-adopt-ads`, `-recruitment-data`, `-audience`, `-heal-reports` | CronJob | adopt v0.1.77 → v0.1.78 |
| `vlab-swoosh` | CronJob | swoosh v0.1.9 → v0.1.10 |
| `vlab-apply-migrations` | Job (hook) | re-runs, no-op — prod already at 20260818000000 |

Nothing else changes. `vlab-conf-dashboard` is the study-conf API at `replicaCount: 1`, so there is a brief gap; that roll is what makes the new destination types loadable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HooztAJBGuViFhXTbFcxBj